### PR TITLE
chore: add automatic linting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+npm run lint

--- a/README.md
+++ b/README.md
@@ -46,9 +46,14 @@ npm run dev
 # Build for production
 npm run build
 
+# Lint code
+npm run lint
+
 # Run tests
 npm run test
 ```
+
+Git hooks are configured to run ESLint automatically before each commit. If hooks are missing, run `npm install` to set them up.
 
 ## MCP Compatibility
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,27 +2,36 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import tsPlugin from '@typescript-eslint/eslint-plugin'
+import tsParser from '@typescript-eslint/parser'
 
-export default tseslint.config(
-  { ignores: ['dist'] },
+export default [
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    ignores: ['dist'],
+  },
+  {
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
+      parser: tsParser,
       ecmaVersion: 2020,
-      globals: globals.browser,
+      sourceType: 'module',
+      globals: { ...globals.browser, ...globals.node },
     },
     plugins: {
+      '@typescript-eslint': tsPlugin,
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
     },
     rules: {
+      ...js.configs.recommended.rules,
+      ...tsPlugin.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },
       ],
     },
   },
-)
+]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:single": "vitest run --singleThread",
     "test:profile": "vitest run --reporter=verbose --slowTestThreshold=1000",
     "typecheck": "tsc --noEmit",
-    "build:pages": "NODE_ENV=production npm run build"
+    "build:pages": "NODE_ENV=production npm run build",
+    "postinstall": "git config core.hooksPath .githooks || true"
   },
   "dependencies": {
     "@headlessui/react": "1.7.17",


### PR DESCRIPTION
## Summary
- configure ESLint without meta package and disable strict TypeScript rules
- add git pre-commit hook to run lint and postinstall to enable hooks
- document lint command and automatic hook setup

## Testing
- `npm run lint`
- `npm run test:fast`


------
https://chatgpt.com/codex/tasks/task_e_68bbec2393f483288d46cc3e5a1f9cfc