### PR TITLE
test: cover PromptCard component

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -11,7 +11,7 @@
 ## Remaining Test Coverage
 
 ### Component Tests (High Priority)
-- [ ] PromptCard component tests - should display prompt information correctly
+- ✅ PromptCard component tests - should display prompt information correctly
 - [ ] PromptRenderer component tests - should render prompt content with arguments
 - [ ] ArgumentsForm component tests - should handle dynamic form inputs
 - [ ] Layout component tests - should render navigation and content areas

--- a/src/components/PromptCard/index.test.tsx
+++ b/src/components/PromptCard/index.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PromptCard from './index'
+
+const samplePrompt = {
+  name: 'test-prompt',
+  title: 'Test Prompt',
+  description: 'A test prompt description',
+  arguments: [
+    { name: 'arg1', description: 'desc1', required: true },
+    { name: 'arg2', description: 'desc2', required: false }
+  ]
+}
+
+describe('PromptCard', () => {
+  it('should display prompt information correctly', () => {
+    render(
+      <MemoryRouter>
+        <PromptCard prompt={samplePrompt} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Test Prompt')).toBeInTheDocument()
+    expect(screen.getByText('A test prompt description')).toBeInTheDocument()
+    expect(screen.getByText('2 arguments')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /view details/i })).toHaveAttribute(
+      'href',
+      '/prompt/test-prompt'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add unit test for PromptCard to verify title, description, arguments count, and detail link
- mark PromptCard tests as complete in development plan

## Testing
- `npm run test:fast`
- `npm run test:components`


------
https://chatgpt.com/codex/tasks/task_e_68bbf0475b008328898f90a390929495