### PR TITLE
Add PromptRenderer argument rendering test

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -12,7 +12,7 @@
 
 ### Component Tests (High Priority)
 - ✅ PromptCard component tests - should display prompt information correctly
-- [ ] PromptRenderer component tests - should render prompt content with arguments
+- ✅ PromptRenderer component tests - should render prompt content with arguments
 - [ ] ArgumentsForm component tests - should handle dynamic form inputs
 - [ ] Layout component tests - should render navigation and content areas
 

--- a/src/components/PromptRenderer/index.test.tsx
+++ b/src/components/PromptRenderer/index.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import PromptRenderer from './index'
+import type { PromptDefinition } from '../../types/prompt'
+
+const samplePrompt: PromptDefinition = {
+  name: 'greet',
+  title: 'Greet',
+  description: 'greeting prompt',
+  messages: [
+    { role: 'user', content: { type: 'text', text: 'Hello {{name}}' } },
+    { role: 'assistant', content: { type: 'text', text: 'Hi {{name}}, nice to meet you.' } }
+  ]
+}
+
+describe('PromptRenderer', () => {
+  it('should render prompt content with arguments', () => {
+    const argumentValues = { name: 'Alice' }
+
+    render(<PromptRenderer prompt={samplePrompt} argumentValues={argumentValues} />)
+
+    expect(screen.getByText('Hello Alice')).toBeInTheDocument()
+    expect(screen.getByText('Hi Alice, nice to meet you.')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- test: ensure PromptRenderer replaces template arguments with provided values
- docs: mark PromptRenderer component tests as complete in plan

## Testing
- `npm run test:fast`


------
https://chatgpt.com/codex/tasks/task_e_68bbf276bb5083288f3e58919088bcc1