### PR TITLE
Refactor prompt rendering into shared helper

### DIFF
--- a/src/components/PromptRenderer/index.tsx
+++ b/src/components/PromptRenderer/index.tsx
@@ -1,5 +1,6 @@
 import ReactMarkdown from 'react-markdown'
 import type { PromptDefinition } from '../../types/prompt'
+import { renderPromptTemplate } from '../../utils/prompt'
 
 interface PromptRendererProps {
   prompt: PromptDefinition
@@ -7,13 +8,6 @@ interface PromptRendererProps {
 }
 
 export default function PromptRenderer({ prompt, argumentValues }: PromptRendererProps) {
-  const renderPromptText = (text: string, args: Record<string, string>) => {
-    return Object.keys(args).reduce((result, key) => {
-      const value = args[key] || `{{${key}}}`
-      return result.replace(new RegExp(`{{${key}}}`, 'g'), value)
-    }, text)
-  }
-
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
       <h3 className="text-lg font-semibold text-gray-900 mb-4">
@@ -45,7 +39,7 @@ export default function PromptRenderer({ prompt, argumentValues }: PromptRendere
             {message.content.type === 'text' && message.content.text && (
               <div className="prose prose-sm max-w-none">
                 <ReactMarkdown>
-                  {renderPromptText(message.content.text, argumentValues)}
+                  {renderPromptTemplate(message.content.text, argumentValues)}
                 </ReactMarkdown>
               </div>
             )}

--- a/src/pages/PromptDetail/index.tsx
+++ b/src/pages/PromptDetail/index.tsx
@@ -9,6 +9,7 @@ import {
 import { usePromptDetail } from '../../hooks/usePromptDetail'
 import PromptRenderer from '../../components/PromptRenderer'
 import ArgumentsForm from '../../components/ArgumentsForm'
+import { renderPromptTemplate } from '../../utils/prompt'
 
 export default function PromptDetail() {
   const { name } = useParams<{ name: string }>()
@@ -19,7 +20,10 @@ export default function PromptDetail() {
   const handleCopyPrompt = async () => {
     if (!prompt) return
 
-    const renderedText = renderPromptText(prompt.messages[0]?.content?.text || '', argumentValues)
+    const renderedText = renderPromptTemplate(
+      prompt.messages[0]?.content?.text || '',
+      argumentValues
+    )
     
     try {
       await navigator.clipboard.writeText(renderedText)
@@ -28,13 +32,6 @@ export default function PromptDetail() {
     } catch (err) {
       console.error('Failed to copy:', err)
     }
-  }
-
-  const renderPromptText = (text: string, args: Record<string, string>) => {
-    return Object.keys(args).reduce((result, key) => {
-      const value = args[key] || `{{${key}}}`
-      return result.replace(new RegExp(`{{${key}}}`, 'g'), value)
-    }, text)
   }
 
   if (loading) {

--- a/src/utils/prompt.test.ts
+++ b/src/utils/prompt.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { validatePrompt, validateArgument, filterPrompts, sortPrompts } from './prompt'
+import {
+  validatePrompt,
+  validateArgument,
+  filterPrompts,
+  sortPrompts,
+  renderPromptTemplate,
+} from './prompt'
 import type { Prompt, PromptArgument } from '../types/prompt'
 
 describe('validatePrompt', () => {
@@ -70,6 +76,7 @@ describe('validatePrompt', () => {
     expect(validatePrompt(prompt)).toBe(false)
   })
 })
+
 
 describe('validateArgument', () => {
   it('should return true for valid argument', () => {
@@ -215,5 +222,28 @@ describe('sortPrompts', () => {
 
     const result = sortPrompts(mixedCasePrompts, 'title')
     expect(result.map(p => p.title)).toEqual(['A-title', 'b-title', 'z-title'])
+  })
+})
+
+describe('renderPromptTemplate', () => {
+  it('should replace placeholders with provided argument values', () => {
+    const template = 'Hello {{name}}'
+    const values = { name: 'Alice' }
+
+    expect(renderPromptTemplate(template, values)).toBe('Hello Alice')
+  })
+
+  it('should keep placeholders intact when argument is missing', () => {
+    const template = 'Hello {{name}} from {{city}}'
+    const values = { name: 'Alice' }
+
+    expect(renderPromptTemplate(template, values)).toBe('Hello Alice from {{city}}')
+  })
+
+  it('should replace repeated placeholders consistently', () => {
+    const template = '{{name}} meets {{name}}'
+    const values = { name: 'Bob' }
+
+    expect(renderPromptTemplate(template, values)).toBe('Bob meets Bob')
   })
 })

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -12,6 +12,7 @@ export function validatePrompt(prompt: Prompt): boolean {
   return true
 }
 
+
 export function validateArgument(argument: PromptArgument): boolean {
   return !!(argument.name && argument.description && typeof argument.required === 'boolean')
 }
@@ -36,4 +37,14 @@ export function sortPrompts(prompts: Prompt[], sortBy: 'name' | 'title' = 'title
     const bValue = b[sortBy].toLowerCase()
     return aValue.localeCompare(bValue)
   })
+}
+
+export function renderPromptTemplate(
+  template: string,
+  argumentValues: Record<string, string>
+): string {
+  return Object.keys(argumentValues).reduce((result, key) => {
+    const value = argumentValues[key] || `{{${key}}}`
+    return result.replace(new RegExp(`{{${key}}}`, 'g'), value)
+  }, template)
 }


### PR DESCRIPTION
## Summary
- extract the prompt placeholder replacement logic into a reusable `renderPromptTemplate` helper
- update PromptDetail and PromptRenderer to consume the shared helper instead of ad-hoc implementations
- add unit coverage for the helper including missing argument and repeated placeholder cases

## Testing
- npm run test:fast

------
https://chatgpt.com/codex/tasks/task_e_68e57d1905ac8328a04c5c10e65ed06d