### PR TITLE
Refactor prompt data sources into generated prompts.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ A curated collection of software gardening prompts for lean development practice
 # Install dependencies
 npm install
 
+# Generate prompts.json from individual prompt files
+npm run generate-prompts
+
 # Start development server
 npm run dev
 
@@ -54,6 +57,10 @@ npm run test
 ```
 
 Git hooks are configured to run ESLint automatically before each commit. If hooks are missing, run `npm install` to set them up.
+
+### Prompt data workflow
+
+Prompt metadata and definitions now live in `data/prompts/*.json`. Each file contains the display information (`name`, `title`, `description`, `arguments`) and the full `messages` array for a single prompt. After editing any of these files, run `npm run generate-prompts` to regenerate `public/prompts.json`. The command is wired into the `prepare`, `dev`, and `build` scripts, but contributors should commit both the modified source files and the regenerated JSON.
 
 ## MCP Compatibility
 

--- a/data/prompts/01-gardener_scout_rule_refactorer.json
+++ b/data/prompts/01-gardener_scout_rule_refactorer.json
@@ -1,0 +1,41 @@
+{
+  "name": "gardener_scout_rule_refactorer",
+  "title": "Gardener · Scout-Rule Refactorer",
+  "description": "Behavior-preserving micro-refactors; tiny reversible steps; always-green CI; XP/Lean/TDD aligned.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Autonomous Software Gardener.\nWORKING STYLE: XP + Lean, TDD first, trunk-based development, walking skeleton, continuous delivery, DDD naming, YAGNI. Keep mainline green.\nSCOPE: {{repo_or_path_glob}}\nTIMEBOX: {{timebox_minutes}} minutes\nLIMITS: ≤ {{max_diff_lines}} changed lines total; ≤ {{max_files}} files touched; avoid files with heavy churn in last {{days}} days.\nTASK:\n1) Identify 1–3 low-risk, high-signal refactors (rename for clarity, extract small pure functions, remove duplication, inline trivial indirections).\n2) Add/strengthen micro-tests BEFORE refactor where coverage is weak. Keep behavior constant.\n3) Run: lint, type-check, unit tests, fast integration.\n4) Prepare ONE PR.\nCONSTRAINTS:\n- No public API changes. No cross-module moves. No formatting-only PRs.\n- Keep commits atomic; intent-revealing commit messages.\nPR TEMPLATE:\nTitle: Gardening: <short noun phrase>\nBody: Problem & rationale; Summary of refactors; Test evidence (commands + counts); Risk assessment (why behavior unchanged); Rollback plan (git revert hash).\nChecklist: [ ] Tests green  [ ] No API changes  [ ] ≤ {{max_diff_lines}} LOC  [ ] Changelog/ADR updated if needed\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "repo_or_path_glob",
+      "description": "Target repository or path glob pattern",
+      "required": true
+    },
+    {
+      "name": "timebox_minutes",
+      "description": "Time limit for the refactoring session in minutes",
+      "required": true
+    },
+    {
+      "name": "max_diff_lines",
+      "description": "Maximum number of changed lines allowed",
+      "required": true
+    },
+    {
+      "name": "max_files",
+      "description": "Maximum number of files to touch",
+      "required": true
+    },
+    {
+      "name": "days",
+      "description": "Number of days to check for heavy churn",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/02-gardener_naming_api_clarity.json
+++ b/data/prompts/02-gardener_naming_api_clarity.json
@@ -1,0 +1,26 @@
+{
+  "name": "gardener_naming_api_clarity",
+  "title": "Gardener · Naming & API Clarity",
+  "description": "DDD-aligned naming, value objects, and intent-revealing APIs without behavior change.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: XP/Lean Software Gardener focused on semantic clarity.\nTARGET: {{module_or_path}}\nLIMITS: Max automated renames ≤ {{max_renames}}. Behavior must not change.\nTASK:\n1) Detect 1–2 naming/API clarity issues (ambiguous method names, anemic value objects, mixed domain/infra terms).\n2) Write characterization tests if missing, then refactor names or extract value objects reflecting the ubiquitous language.\n3) Update references via IDE-safe/AST-safe refactors.\n4) Run unit → component → smoke tests.\nOUTPUT: Single PR including short domain glossary snippet, before/after examples, and test evidence. Avoid breaking external consumers.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "module_or_path",
+      "description": "Target module or path to refactor",
+      "required": true
+    },
+    {
+      "name": "max_renames",
+      "description": "Maximum number of automated renames allowed",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/03-gardener_deadcode_dup_pruner.json
+++ b/data/prompts/03-gardener_deadcode_dup_pruner.json
@@ -1,0 +1,36 @@
+{
+  "name": "gardener_deadcode_dup_pruner",
+  "title": "Gardener · Dead Code & Duplication Pruner",
+  "description": "Evidence-driven deletion and tiny DRY merges with strict safety gates.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Software Gardener prioritizing simplicity and basal cost reduction.\nTARGET PATHS: {{paths}}\nEVIDENCE SOURCES: Coverage/Runtime via {{coverage_cmd}}; Git inactivity threshold {{stale_days}} days; static search (unreferenced symbols/branches).\nLIMITS: Max deletions ≤ {{max_deleted_lines}} lines; keep public API intact.\nTASK:\n1) Prove unreachability for dead code candidates (search/build/coverage evidence).\n2) Add/boost tests at remaining call sites to preserve behavior.\n3) Delete dead code or merge tiny duplications (≤ 25 lines each) via extract method.\nPR BODY must include an Evidence Table (symbol → refs → coverage → decision), risks, and rollback.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "paths",
+      "description": "Target paths to analyze for dead code",
+      "required": true
+    },
+    {
+      "name": "coverage_cmd",
+      "description": "Command to check coverage/runtime",
+      "required": true
+    },
+    {
+      "name": "stale_days",
+      "description": "Git inactivity threshold in days",
+      "required": true
+    },
+    {
+      "name": "max_deleted_lines",
+      "description": "Maximum number of lines to delete",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/04-gardener_complexity_reducer.json
+++ b/data/prompts/04-gardener_complexity_reducer.json
@@ -1,0 +1,31 @@
+{
+  "name": "gardener_complexity_reducer",
+  "title": "Gardener · Complexity Reducer",
+  "description": "Lower cyclomatic/cognitive complexity via small extractions; keep behavior constant.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Complexity Reducer using tiny, reversible steps.\nHOTSPOTS: Ranked by {{report_path_or_cmd}}\nLIMITS: ≤ {{max_diff_lines}} changed lines; ≤ {{max_new_classes}} small strategy/command objects.\nTASK:\n1) Select top 1–2 hotspots.\n2) Add/strengthen narrow tests around current behavior.\n3) Extract pure helpers; isolate side effects behind thin interfaces; use guard clauses to flatten nesting.\n4) Provide before/after complexity metrics.\nCONSTRAINTS: No new external dependencies; no public API change.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "report_path_or_cmd",
+      "description": "Path to complexity report or command to generate it",
+      "required": true
+    },
+    {
+      "name": "max_diff_lines",
+      "description": "Maximum number of changed lines allowed",
+      "required": true
+    },
+    {
+      "name": "max_new_classes",
+      "description": "Maximum number of new strategy/command objects",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/05-gardener_test_suite_gardener.json
+++ b/data/prompts/05-gardener_test_suite_gardener.json
@@ -1,0 +1,26 @@
+{
+  "name": "gardener_test_suite_gardener",
+  "title": "Gardener · Test Gardener",
+  "description": "Strengthen tests first; eliminate flakiness and reduce runtime without losing signal.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Test Gardener.\nTARGET: {{test_paths}}\nGOAL: Reduce total test runtime by ≥ {{runtime_pct}}% and remove flaky patterns.\nTASK:\n1) Identify 1–2 brittle/slow tests (sleep/polling, network/file I/O, shared mutable state).\n2) Introduce seams (ports/adapters) to stub external systems; prefer table-driven or property-based tests for pure logic.\n3) Replace broad E2E checks with focused component tests where appropriate; add missing edge-case tests; remove redundant overlaps.\nOUTPUT: PR with runtime before/after, flakiness notes, and evidence that coverage/signal did not regress.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "test_paths",
+      "description": "Target test paths to improve",
+      "required": true
+    },
+    {
+      "name": "runtime_pct",
+      "description": "Target percentage reduction in runtime",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/06-gardener_dependency_gardener.json
+++ b/data/prompts/06-gardener_dependency_gardener.json
@@ -1,0 +1,26 @@
+{
+  "name": "gardener_dependency_gardener",
+  "title": "Gardener · Dependency Gardener",
+  "description": "Safe micro-upgrades (patch/minor), one logical upgrade per PR, full CI + smoke check and explicit rollback.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Dependency Gardener.\nTARGET: {{manifest_path_or_list}}\nSMOKE: {{smoke_cmd}}\nTASK:\n1) Propose 1–2 patch/minor upgrades with the lowest blast radius.\n2) Refresh lockfile; run full tests and smoke deployment/runtime.\n3) If breaking changes appear, either adapt with minimal edits or skip; avoid majors unless explicitly allowed.\nOUTPUT: One PR per logical upgrade with changelog snippets, compatibility notes, and rollback instructions.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "manifest_path_or_list",
+      "description": "Path to package manifest or list of dependencies",
+      "required": true
+    },
+    {
+      "name": "smoke_cmd",
+      "description": "Command to run smoke tests",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/07-gardener_parallel_change_preparer.json
+++ b/data/prompts/07-gardener_parallel_change_preparer.json
@@ -1,0 +1,36 @@
+{
+  "name": "gardener_parallel_change_preparer",
+  "title": "Gardener · Parallel-Change Preparer",
+  "description": "Introduce a reversible seam (parallel change) with a default-OFF flag; old and new paths must both work.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Parallel-Change Preparer.\nTARGET: {{target_component}}\nSEAM: New interface/adapter {{new_iface_name}}; flag {{flag_name}} (default OFF).\nLIMITS: ≤ {{max_diff_lines}} changed lines; add characterization tests for old path and equivalent tests for new path behind the flag.\nTASK:\n1) Introduce the new interface/adapter that mirrors behavior.\n2) Implement toggled path; keep both paths green in CI.\n3) Add lightweight metrics/logs to compare behavior when toggled in staging.\nOUTPUT: PR explaining the parallel change plan and next steps; ensure no user-visible behavior change.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "target_component",
+      "description": "Component to prepare for parallel change",
+      "required": true
+    },
+    {
+      "name": "new_iface_name",
+      "description": "Name for the new interface/adapter",
+      "required": true
+    },
+    {
+      "name": "flag_name",
+      "description": "Name for the feature flag",
+      "required": true
+    },
+    {
+      "name": "max_diff_lines",
+      "description": "Maximum number of changed lines allowed",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/08-gardener_boundary_clarifier.json
+++ b/data/prompts/08-gardener_boundary_clarifier.json
@@ -1,0 +1,21 @@
+{
+  "name": "gardener_boundary_clarifier",
+  "title": "Gardener · Boundary Clarifier",
+  "description": "Tighten domain/infra boundaries using ports/adapters with minimal code movement.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Boundary Clarifier (DDD).\nTARGET DOMAIN MODULE: {{domain_module}}\nTASK:\n1) Identify a direct infra call inside domain logic.\n2) Wrap it behind a port interface; move infra details to an adapter.\n3) Add tests at the port boundary; stub the adapter in domain tests.\nCONSTRAINTS: No schema/API changes. One boundary at a time. Max new types: 1 interface + 1 adapter.\nOUTPUT: PR with mini-ADR: context, decision, consequences.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "domain_module",
+      "description": "Target domain module to clarify boundaries",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/09-gardener_invariant_guardrails.json
+++ b/data/prompts/09-gardener_invariant_guardrails.json
@@ -1,0 +1,21 @@
+{
+  "name": "gardener_invariant_guardrails",
+  "title": "Gardener · Invariant Guardrails",
+  "description": "Add value objects/validations and fast-fail assertions/logs to defend key domain invariants.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Invariant Guardrails.\nTARGET: {{aggregate_or_entity}}\nTASK:\n1) Introduce/upgrade value objects with validated constructors.\n2) Add fast-fail assertions in dev/test and structured logs in prod for violations.\n3) Extend tests for invalid inputs and boundary conditions.\nCONSTRAINTS: No behavior changes for valid inputs. Logs rate-limited and structured.\nOUTPUT: PR documenting the invariant and how it's enforced.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "aggregate_or_entity",
+      "description": "Target aggregate or entity to add guardrails",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/10-gardener_fitness_functions.json
+++ b/data/prompts/10-gardener_fitness_functions.json
@@ -1,0 +1,26 @@
+{
+  "name": "gardener_fitness_functions",
+  "title": "Gardener · Fitness-Function Writer",
+  "description": "Codify small architectural rules as fast checks/tests and wire them into CI.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Fitness-Function Writer.\nTOOLING: {{tooling_choice}}\nLOCATION: {{tooling_path}}\nTASK:\n1) Add 1–2 narrowly-scoped rules (examples: 'domain cannot import infra', 'no network calls in unit tests', 'max function length 60').\n2) Implement with the chosen tooling and integrate into CI.\n3) Provide guided suppressions for legacy files with TODO expiry dates.\nOUTPUT: PR with rule descriptions, rationale, and remediation guidance; include failing-example reproduction and how to fix.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "tooling_choice",
+      "description": "Tooling to use for implementing fitness functions",
+      "required": true
+    },
+    {
+      "name": "tooling_path",
+      "description": "Path to place the fitness function tooling",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/11-gardener_cohesion_analyzer.json
+++ b/data/prompts/11-gardener_cohesion_analyzer.json
@@ -1,0 +1,31 @@
+{
+  "name": "gardener_cohesion_analyzer",
+  "title": "Gardener · Cohesion Analyzer",
+  "description": "Identify components with mixed responsibilities and extract secondary concerns.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Software Gardener specialized in cohesion analysis.\nTARGET: {{module_or_class_path}}\nLIMITS: Max {{max_extractions}} extracted components; ≤ {{max_diff_lines}} changed lines total.\nTASK:\n1) Analyze component for single responsibility violations (mixed domains, unrelated methods, functions that seem out of place).\n2) Identify secondary responsibilities that can be extracted into focused components.\n3) Add characterization tests before extraction to preserve behavior.\n4) Extract mixed concerns using small, reversible steps (extract method → extract class).\n5) Validate isolation: can each component be tested independently?\nCONSTRAINTS:\n- Keep behavior constant; no public API changes.\n- Consistent naming to maintain cohesion within extracted components.\n- Avoid cross-module dependencies in extractions.\nOUTPUT: PR with cohesion analysis report (before/after responsibility matrix), extracted components list, and test evidence that behavior is preserved.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "module_or_class_path",
+      "description": "Target module or class to analyze for cohesion issues",
+      "required": true
+    },
+    {
+      "name": "max_extractions",
+      "description": "Maximum number of extracted components allowed",
+      "required": true
+    },
+    {
+      "name": "max_diff_lines",
+      "description": "Maximum number of changed lines allowed",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/12-gardener_coupling_reducer.json
+++ b/data/prompts/12-gardener_coupling_reducer.json
@@ -1,0 +1,31 @@
+{
+  "name": "gardener_coupling_reducer",
+  "title": "Gardener · Coupling Reducer",
+  "description": "Reduce inter-module dependencies through interfaces and dependency injection.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Decoupling Specialist using ports/adapters pattern.\nTARGET: {{high_coupling_module}}\nLIMITS: Max {{max_interfaces}} new interfaces; ≤ {{max_diff_lines}} changed lines; behavior must remain unchanged.\nTASK:\n1) Identify tight coupling points using static analysis (direct imports, shared data structures, concrete dependencies).\n2) Introduce interfaces to break direct dependencies between modules.\n3) Implement dependency injection where beneficial for testability and flexibility.\n4) Replace shared data structures with defined contracts/interfaces.\n5) Add isolation tests at new boundaries to verify decoupling.\nCONSTRAINTS:\n- Keep behavior constant; no public API changes.\n- Avoid sharing data structures between modules.\n- Test each module in isolation after decoupling.\nOUTPUT: PR with coupling metrics report (before/after dependency graph), interface definitions, and test evidence demonstrating improved isolation.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "high_coupling_module",
+      "description": "Target module with tight coupling to analyze and refactor",
+      "required": true
+    },
+    {
+      "name": "max_interfaces",
+      "description": "Maximum number of new interfaces to introduce",
+      "required": true
+    },
+    {
+      "name": "max_diff_lines",
+      "description": "Maximum number of changed lines allowed",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/13-gardener_encapsulation_strengthener.json
+++ b/data/prompts/13-gardener_encapsulation_strengthener.json
@@ -1,0 +1,31 @@
+{
+  "name": "gardener_encapsulation_strengthener",
+  "title": "Gardener · Encapsulation Strengthener",
+  "description": "Hide internal details behind meaningful operations and behavior-focused interfaces.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Encapsulation Guardian focused on information hiding.\nTARGET: {{component_path}}\nLIMITS: No public API breaking changes; ≤ {{max_new_methods}} new public methods; ≤ {{max_diff_lines}} changed lines.\nTASK:\n1) Audit exposed internals vs actual usage patterns (getters/setters exposing state, public fields, implementation details).\n2) Replace data accessors with behavior-focused operations that show intention, not implementation.\n3) Hide implementation details behind abstractions that protect against future changes.\n4) Make internal state private and provide meaningful operations instead of raw data access.\n5) Validate no external consumers break after encapsulation improvements.\nCONSTRAINTS:\n- Show intention, not implementation in public interfaces.\n- Minimize exposure as much as possible while maintaining functionality.\n- Prefer meaningful operations over raw data access.\nOUTPUT: PR with API surface analysis (before/after exposure metrics), encapsulation improvements list, and test evidence that external usage patterns remain valid.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "component_path",
+      "description": "Target component to strengthen encapsulation",
+      "required": true
+    },
+    {
+      "name": "max_new_methods",
+      "description": "Maximum number of new public methods to introduce",
+      "required": true
+    },
+    {
+      "name": "max_diff_lines",
+      "description": "Maximum number of changed lines allowed",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/14-gardener_clarity_enhancer.json
+++ b/data/prompts/14-gardener_clarity_enhancer.json
@@ -1,0 +1,31 @@
+{
+  "name": "gardener_clarity_enhancer",
+  "title": "Gardener · Clarity Enhancer",
+  "description": "Make code self-explanatory through descriptive naming and predictable interfaces.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Code Clarity Specialist focused on obviousness.\nTARGET: {{module_or_package}}\nLIMITS: Max {{max_renames}} automated renames; ≤ {{max_diff_lines}} changed lines; preserve all behavior.\nTASK:\n1) Identify unclear method/variable names using intent-revealing patterns (ambiguous names, abbreviated terms, misleading names).\n2) Analyze predictability of operations and their side effects (surprising behavior, inconsistent naming patterns).\n3) Rename using domain-appropriate, descriptive terms that make purpose immediately clear.\n4) Ensure method results are predictable and interfaces are intuitive without documentation.\n5) Verify usage remains clear and self-explanatory to new developers.\nCONSTRAINTS:\n- Use descriptive and consistent names throughout.\n- Avoid surprises: maintain consistency in naming patterns.\n- Make code readable without requiring documentation.\nOUTPUT: PR with clarity improvement report (before/after naming examples), consistency analysis, and evidence that code is now self-explanatory and intuitive to use.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "module_or_package",
+      "description": "Target module or package to enhance clarity",
+      "required": true
+    },
+    {
+      "name": "max_renames",
+      "description": "Maximum number of automated renames allowed",
+      "required": true
+    },
+    {
+      "name": "max_diff_lines",
+      "description": "Maximum number of changed lines allowed",
+      "required": true
+    }
+  ]
+}

--- a/data/prompts/15-gardener_design_principles_auditor.json
+++ b/data/prompts/15-gardener_design_principles_auditor.json
@@ -1,0 +1,31 @@
+{
+  "name": "gardener_design_principles_auditor",
+  "title": "Gardener · Design Principles Auditor",
+  "description": "Comprehensive design health check using cohesion, coupling, encapsulation, and clarity principles.",
+  "messages": [
+    {
+      "role": "user",
+      "content": {
+        "type": "text",
+        "text": "ROLE: Design Health Inspector using proven design principles.\nTARGET: {{codebase_path}}\nFOCUS: {{focus_area}} (cohesion|coupling|hiding|clarity|all)\nLIMITS: Max {{max_priority_fixes}} priority fixes; behavior must remain unchanged.\nTASK:\n1) Run comprehensive design analysis using the four core principles:\n   - COHESION: Does each module have a single clear responsibility?\n   - COUPLING: How much does each part depend on the rest of the system?\n   - INFORMATION HIDING: Are we exposing only what is necessary?\n   - OBVIOUS SYSTEM: Does the code explain itself?\n2) Apply the design health checklist to sample key components:\n   - Does each module have a clear purpose?\n   - Could I change this without breaking half the system?\n   - Am I exposing the minimum necessary?\n   - Would a new team member understand this without help?\n3) Identify top {{max_priority_fixes}} design debt items with concrete examples and measurable impact.\n4) Provide actionable remediation plan with effort estimates and risk assessment.\nCONSTRAINTS:\n- No behavior changes during analysis phase.\n- Focus on structural improvements that enhance maintainability.\n- Prioritize changes with highest impact-to-effort ratio.\nOUTPUT: PR with comprehensive design health report including: principles scorecard (0-10 for each principle), design debt inventory with priority ranking, actionable improvement roadmap, and baseline metrics for future comparison.\n"
+      }
+    }
+  ],
+  "arguments": [
+    {
+      "name": "codebase_path",
+      "description": "Target codebase path to audit for design principles",
+      "required": true
+    },
+    {
+      "name": "focus_area",
+      "description": "Focus area for analysis: cohesion, coupling, hiding, clarity, or all",
+      "required": true
+    },
+    {
+      "name": "max_priority_fixes",
+      "description": "Maximum number of priority fixes to implement",
+      "required": true
+    }
+  ]
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -64,6 +64,16 @@ npm run test:unit        # Only unit tests
 npm run test:components  # Only component tests
 ```
 
+### Prompt Data Workflow
+
+Prompt definitions are stored as individual files under `data/prompts/`. Each JSON file includes the prompt's list metadata (`name`, `title`, `description`, `arguments`) and the full `messages` payload. After editing or adding a prompt file, run:
+
+```bash
+npm run generate-prompts
+```
+
+The generator rebuilds `public/prompts.json`, which powers the UI and MCP endpoint. This command runs automatically during `npm run dev`, `npm run build`, and as part of the `prepare` script, but contributors must ensure the regenerated `public/prompts.json` is committed alongside the source prompt files.
+
 ### Build Scripts
 ```bash
 npm run build            # Standard build

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build",
+    "generate-prompts": "node scripts/generate-prompts.mjs",
+    "prepare": "npm run generate-prompts",
+    "dev": "npm run generate-prompts && vite",
+    "build": "npm run generate-prompts && tsc && vite build",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest run",

--- a/public/prompts.json
+++ b/public/prompts.json
@@ -1,167 +1,761 @@
 {
   "prompts": [
-    { 
-      "name": "gardener_scout_rule_refactorer", 
-      "title": "Gardener · Scout-Rule Refactorer", 
-      "description": "Behavior-preserving micro-refactors in tiny reversible steps; always-green CI; XP/Lean/TDD aligned.",
+    {
+      "name": "gardener_scout_rule_refactorer",
+      "title": "Gardener · Scout-Rule Refactorer",
+      "description": "Behavior-preserving micro-refactors; tiny reversible steps; always-green CI; XP/Lean/TDD aligned.",
       "arguments": [
-        { "name": "repo_or_path_glob", "description": "Target repository or path glob pattern", "required": true },
-        { "name": "timebox_minutes", "description": "Time limit for the refactoring session in minutes", "required": true },
-        { "name": "max_diff_lines", "description": "Maximum number of changed lines allowed", "required": true },
-        { "name": "max_files", "description": "Maximum number of files to touch", "required": true },
-        { "name": "days", "description": "Number of days to check for heavy churn", "required": true }
+        {
+          "name": "repo_or_path_glob",
+          "description": "Target repository or path glob pattern",
+          "required": true
+        },
+        {
+          "name": "timebox_minutes",
+          "description": "Time limit for the refactoring session in minutes",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        },
+        {
+          "name": "max_files",
+          "description": "Maximum number of files to touch",
+          "required": true
+        },
+        {
+          "name": "days",
+          "description": "Number of days to check for heavy churn",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_naming_api_clarity", 
-      "title": "Gardener · Naming & API Clarity", 
+    {
+      "name": "gardener_naming_api_clarity",
+      "title": "Gardener · Naming & API Clarity",
       "description": "DDD-aligned naming, value objects, and intent-revealing APIs without behavior change.",
       "arguments": [
-        { "name": "module_or_path", "description": "Target module or path to refactor", "required": true },
-        { "name": "max_renames", "description": "Maximum number of automated renames allowed", "required": true }
+        {
+          "name": "module_or_path",
+          "description": "Target module or path to refactor",
+          "required": true
+        },
+        {
+          "name": "max_renames",
+          "description": "Maximum number of automated renames allowed",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_deadcode_dup_pruner", 
-      "title": "Gardener · Dead Code & Duplication Pruner", 
+    {
+      "name": "gardener_deadcode_dup_pruner",
+      "title": "Gardener · Dead Code & Duplication Pruner",
       "description": "Evidence-driven deletion and tiny DRY merges with strict safety gates.",
       "arguments": [
-        { "name": "paths", "description": "Target paths to analyze for dead code", "required": true },
-        { "name": "coverage_cmd", "description": "Command to check coverage/runtime", "required": true },
-        { "name": "stale_days", "description": "Git inactivity threshold in days", "required": true },
-        { "name": "max_deleted_lines", "description": "Maximum number of lines to delete", "required": true }
+        {
+          "name": "paths",
+          "description": "Target paths to analyze for dead code",
+          "required": true
+        },
+        {
+          "name": "coverage_cmd",
+          "description": "Command to check coverage/runtime",
+          "required": true
+        },
+        {
+          "name": "stale_days",
+          "description": "Git inactivity threshold in days",
+          "required": true
+        },
+        {
+          "name": "max_deleted_lines",
+          "description": "Maximum number of lines to delete",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_complexity_reducer", 
-      "title": "Gardener · Complexity Reducer", 
-      "description": "Lower cyclomatic/cognitive complexity via small, behavior-preserving extractions.",
+    {
+      "name": "gardener_complexity_reducer",
+      "title": "Gardener · Complexity Reducer",
+      "description": "Lower cyclomatic/cognitive complexity via small extractions; keep behavior constant.",
       "arguments": [
-        { "name": "report_path_or_cmd", "description": "Path to complexity report or command to generate it", "required": true },
-        { "name": "max_diff_lines", "description": "Maximum number of changed lines allowed", "required": true },
-        { "name": "max_new_classes", "description": "Maximum number of new strategy/command objects", "required": true }
+        {
+          "name": "report_path_or_cmd",
+          "description": "Path to complexity report or command to generate it",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        },
+        {
+          "name": "max_new_classes",
+          "description": "Maximum number of new strategy/command objects",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_test_suite_gardener", 
-      "title": "Gardener · Test Gardener", 
-      "description": "Strengthen tests first; kill flakiness/slow tests; introduce seams safely.",
+    {
+      "name": "gardener_test_suite_gardener",
+      "title": "Gardener · Test Gardener",
+      "description": "Strengthen tests first; eliminate flakiness and reduce runtime without losing signal.",
       "arguments": [
-        { "name": "test_paths", "description": "Target test paths to improve", "required": true },
-        { "name": "runtime_pct", "description": "Target percentage reduction in runtime", "required": true }
+        {
+          "name": "test_paths",
+          "description": "Target test paths to improve",
+          "required": true
+        },
+        {
+          "name": "runtime_pct",
+          "description": "Target percentage reduction in runtime",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_dependency_gardener", 
-      "title": "Gardener · Dependency Gardener", 
-      "description": "Safe micro-upgrades (patch/minor), one logical upgrade per PR, full CI + smoke check.",
+    {
+      "name": "gardener_dependency_gardener",
+      "title": "Gardener · Dependency Gardener",
+      "description": "Safe micro-upgrades (patch/minor), one logical upgrade per PR, full CI + smoke check and explicit rollback.",
       "arguments": [
-        { "name": "manifest_path_or_list", "description": "Path to package manifest or list of dependencies", "required": true },
-        { "name": "smoke_cmd", "description": "Command to run smoke tests", "required": true }
+        {
+          "name": "manifest_path_or_list",
+          "description": "Path to package manifest or list of dependencies",
+          "required": true
+        },
+        {
+          "name": "smoke_cmd",
+          "description": "Command to run smoke tests",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_parallel_change_preparer", 
-      "title": "Gardener · Parallel-Change Preparer", 
-      "description": "Introduce a reversible seam with a toggle/flag; keep old and new paths working.",
+    {
+      "name": "gardener_parallel_change_preparer",
+      "title": "Gardener · Parallel-Change Preparer",
+      "description": "Introduce a reversible seam (parallel change) with a default-OFF flag; old and new paths must both work.",
       "arguments": [
-        { "name": "target_component", "description": "Component to prepare for parallel change", "required": true },
-        { "name": "new_iface_name", "description": "Name for the new interface/adapter", "required": true },
-        { "name": "flag_name", "description": "Name for the feature flag", "required": true },
-        { "name": "max_diff_lines", "description": "Maximum number of changed lines allowed", "required": true }
+        {
+          "name": "target_component",
+          "description": "Component to prepare for parallel change",
+          "required": true
+        },
+        {
+          "name": "new_iface_name",
+          "description": "Name for the new interface/adapter",
+          "required": true
+        },
+        {
+          "name": "flag_name",
+          "description": "Name for the feature flag",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_boundary_clarifier", 
-      "title": "Gardener · Boundary Clarifier", 
-      "description": "Tighten domain/infra boundaries (ports/adapters) in tiny steps.",
+    {
+      "name": "gardener_boundary_clarifier",
+      "title": "Gardener · Boundary Clarifier",
+      "description": "Tighten domain/infra boundaries using ports/adapters with minimal code movement.",
       "arguments": [
-        { "name": "domain_module", "description": "Target domain module to clarify boundaries", "required": true }
+        {
+          "name": "domain_module",
+          "description": "Target domain module to clarify boundaries",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_invariant_guardrails", 
-      "title": "Gardener · Invariant Guardrails", 
-      "description": "Add value objects/validations and fast-fail assertions for key invariants.",
+    {
+      "name": "gardener_invariant_guardrails",
+      "title": "Gardener · Invariant Guardrails",
+      "description": "Add value objects/validations and fast-fail assertions/logs to defend key domain invariants.",
       "arguments": [
-        { "name": "aggregate_or_entity", "description": "Target aggregate or entity to add guardrails", "required": true }
+        {
+          "name": "aggregate_or_entity",
+          "description": "Target aggregate or entity to add guardrails",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_fitness_functions", 
-      "title": "Gardener · Fitness-Function Writer", 
-      "description": "Encode small architecture rules as tests/static checks; wire into CI.",
+    {
+      "name": "gardener_fitness_functions",
+      "title": "Gardener · Fitness-Function Writer",
+      "description": "Codify small architectural rules as fast checks/tests and wire them into CI.",
       "arguments": [
-        { "name": "tooling_choice", "description": "Tooling to use for implementing fitness functions", "required": true },
-        { "name": "tooling_path", "description": "Path to place the fitness function tooling", "required": true }
+        {
+          "name": "tooling_choice",
+          "description": "Tooling to use for implementing fitness functions",
+          "required": true
+        },
+        {
+          "name": "tooling_path",
+          "description": "Path to place the fitness function tooling",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_cohesion_analyzer", 
-      "title": "Gardener · Cohesion Analyzer", 
+    {
+      "name": "gardener_cohesion_analyzer",
+      "title": "Gardener · Cohesion Analyzer",
       "description": "Identify components with mixed responsibilities and extract secondary concerns.",
       "arguments": [
-        { "name": "module_or_class_path", "description": "Target module or class to analyze for cohesion issues", "required": true },
-        { "name": "max_extractions", "description": "Maximum number of extracted components allowed", "required": true },
-        { "name": "max_diff_lines", "description": "Maximum number of changed lines allowed", "required": true }
+        {
+          "name": "module_or_class_path",
+          "description": "Target module or class to analyze for cohesion issues",
+          "required": true
+        },
+        {
+          "name": "max_extractions",
+          "description": "Maximum number of extracted components allowed",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_coupling_reducer", 
-      "title": "Gardener · Coupling Reducer", 
+    {
+      "name": "gardener_coupling_reducer",
+      "title": "Gardener · Coupling Reducer",
       "description": "Reduce inter-module dependencies through interfaces and dependency injection.",
       "arguments": [
-        { "name": "high_coupling_module", "description": "Target module with tight coupling to analyze and refactor", "required": true },
-        { "name": "max_interfaces", "description": "Maximum number of new interfaces to introduce", "required": true },
-        { "name": "max_diff_lines", "description": "Maximum number of changed lines allowed", "required": true }
+        {
+          "name": "high_coupling_module",
+          "description": "Target module with tight coupling to analyze and refactor",
+          "required": true
+        },
+        {
+          "name": "max_interfaces",
+          "description": "Maximum number of new interfaces to introduce",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_encapsulation_strengthener", 
-      "title": "Gardener · Encapsulation Strengthener", 
+    {
+      "name": "gardener_encapsulation_strengthener",
+      "title": "Gardener · Encapsulation Strengthener",
       "description": "Hide internal details behind meaningful operations and behavior-focused interfaces.",
       "arguments": [
-        { "name": "component_path", "description": "Target component to strengthen encapsulation", "required": true },
-        { "name": "max_new_methods", "description": "Maximum number of new public methods to introduce", "required": true },
-        { "name": "max_diff_lines", "description": "Maximum number of changed lines allowed", "required": true }
+        {
+          "name": "component_path",
+          "description": "Target component to strengthen encapsulation",
+          "required": true
+        },
+        {
+          "name": "max_new_methods",
+          "description": "Maximum number of new public methods to introduce",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_clarity_enhancer", 
-      "title": "Gardener · Clarity Enhancer", 
+    {
+      "name": "gardener_clarity_enhancer",
+      "title": "Gardener · Clarity Enhancer",
       "description": "Make code self-explanatory through descriptive naming and predictable interfaces.",
       "arguments": [
-        { "name": "module_or_package", "description": "Target module or package to enhance clarity", "required": true },
-        { "name": "max_renames", "description": "Maximum number of automated renames allowed", "required": true },
-        { "name": "max_diff_lines", "description": "Maximum number of changed lines allowed", "required": true }
+        {
+          "name": "module_or_package",
+          "description": "Target module or package to enhance clarity",
+          "required": true
+        },
+        {
+          "name": "max_renames",
+          "description": "Maximum number of automated renames allowed",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
       ]
     },
-    { 
-      "name": "gardener_design_principles_auditor", 
-      "title": "Gardener · Design Principles Auditor", 
+    {
+      "name": "gardener_design_principles_auditor",
+      "title": "Gardener · Design Principles Auditor",
       "description": "Comprehensive design health check using cohesion, coupling, encapsulation, and clarity principles.",
       "arguments": [
-        { "name": "codebase_path", "description": "Target codebase path to audit for design principles", "required": true },
-        { "name": "focus_area", "description": "Focus area for analysis: cohesion, coupling, hiding, clarity, or all", "required": true },
-        { "name": "max_priority_fixes", "description": "Maximum number of priority fixes to implement", "required": true }
+        {
+          "name": "codebase_path",
+          "description": "Target codebase path to audit for design principles",
+          "required": true
+        },
+        {
+          "name": "focus_area",
+          "description": "Focus area for analysis: cohesion, coupling, hiding, clarity, or all",
+          "required": true
+        },
+        {
+          "name": "max_priority_fixes",
+          "description": "Maximum number of priority fixes to implement",
+          "required": true
+        }
       ]
     }
   ],
   "definitions": {
-    "gardener_scout_rule_refactorer": { "name": "gardener_scout_rule_refactorer", "title": "Gardener · Scout-Rule Refactorer", "description": "Behavior-preserving micro-refactors; tiny reversible steps; always-green CI; XP/Lean/TDD aligned.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Autonomous Software Gardener.\nWORKING STYLE: XP + Lean, TDD first, trunk-based development, walking skeleton, continuous delivery, DDD naming, YAGNI. Keep mainline green.\nSCOPE: {{repo_or_path_glob}}\nTIMEBOX: {{timebox_minutes}} minutes\nLIMITS: ≤ {{max_diff_lines}} changed lines total; ≤ {{max_files}} files touched; avoid files with heavy churn in last {{days}} days.\nTASK:\n1) Identify 1–3 low-risk, high-signal refactors (rename for clarity, extract small pure functions, remove duplication, inline trivial indirections).\n2) Add/strengthen micro-tests BEFORE refactor where coverage is weak. Keep behavior constant.\n3) Run: lint, type-check, unit tests, fast integration.\n4) Prepare ONE PR.\nCONSTRAINTS:\n- No public API changes. No cross-module moves. No formatting-only PRs.\n- Keep commits atomic; intent-revealing commit messages.\nPR TEMPLATE:\nTitle: Gardening: <short noun phrase>\nBody: Problem & rationale; Summary of refactors; Test evidence (commands + counts); Risk assessment (why behavior unchanged); Rollback plan (git revert hash).\nChecklist: [ ] Tests green  [ ] No API changes  [ ] ≤ {{max_diff_lines}} LOC  [ ] Changelog/ADR updated if needed\n" } } ] },
-    "gardener_naming_api_clarity": { "name": "gardener_naming_api_clarity", "title": "Gardener · Naming & API Clarity", "description": "DDD-aligned naming, value objects, and intent-revealing APIs without behavior change.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: XP/Lean Software Gardener focused on semantic clarity.\nTARGET: {{module_or_path}}\nLIMITS: Max automated renames ≤ {{max_renames}}. Behavior must not change.\nTASK:\n1) Detect 1–2 naming/API clarity issues (ambiguous method names, anemic value objects, mixed domain/infra terms).\n2) Write characterization tests if missing, then refactor names or extract value objects reflecting the ubiquitous language.\n3) Update references via IDE-safe/AST-safe refactors.\n4) Run unit → component → smoke tests.\nOUTPUT: Single PR including short domain glossary snippet, before/after examples, and test evidence. Avoid breaking external consumers.\n" } } ] },
-    "gardener_deadcode_dup_pruner": { "name": "gardener_deadcode_dup_pruner", "title": "Gardener · Dead Code & Duplication Pruner", "description": "Evidence-driven deletion and tiny DRY merges with strict safety gates.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Software Gardener prioritizing simplicity and basal cost reduction.\nTARGET PATHS: {{paths}}\nEVIDENCE SOURCES: Coverage/Runtime via {{coverage_cmd}}; Git inactivity threshold {{stale_days}} days; static search (unreferenced symbols/branches).\nLIMITS: Max deletions ≤ {{max_deleted_lines}} lines; keep public API intact.\nTASK:\n1) Prove unreachability for dead code candidates (search/build/coverage evidence).\n2) Add/boost tests at remaining call sites to preserve behavior.\n3) Delete dead code or merge tiny duplications (≤ 25 lines each) via extract method.\nPR BODY must include an Evidence Table (symbol → refs → coverage → decision), risks, and rollback.\n" } } ] },
-    "gardener_complexity_reducer": { "name": "gardener_complexity_reducer", "title": "Gardener · Complexity Reducer", "description": "Lower cyclomatic/cognitive complexity via small extractions; keep behavior constant.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Complexity Reducer using tiny, reversible steps.\nHOTSPOTS: Ranked by {{report_path_or_cmd}}\nLIMITS: ≤ {{max_diff_lines}} changed lines; ≤ {{max_new_classes}} small strategy/command objects.\nTASK:\n1) Select top 1–2 hotspots.\n2) Add/strengthen narrow tests around current behavior.\n3) Extract pure helpers; isolate side effects behind thin interfaces; use guard clauses to flatten nesting.\n4) Provide before/after complexity metrics.\nCONSTRAINTS: No new external dependencies; no public API change.\n" } } ] },
-    "gardener_test_suite_gardener": { "name": "gardener_test_suite_gardener", "title": "Gardener · Test Gardener", "description": "Strengthen tests first; eliminate flakiness and reduce runtime without losing signal.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Test Gardener.\nTARGET: {{test_paths}}\nGOAL: Reduce total test runtime by ≥ {{runtime_pct}}% and remove flaky patterns.\nTASK:\n1) Identify 1–2 brittle/slow tests (sleep/polling, network/file I/O, shared mutable state).\n2) Introduce seams (ports/adapters) to stub external systems; prefer table-driven or property-based tests for pure logic.\n3) Replace broad E2E checks with focused component tests where appropriate; add missing edge-case tests; remove redundant overlaps.\nOUTPUT: PR with runtime before/after, flakiness notes, and evidence that coverage/signal did not regress.\n" } } ] },
-    "gardener_dependency_gardener": { "name": "gardener_dependency_gardener", "title": "Gardener · Dependency Gardener", "description": "Safe micro-upgrades (patch/minor), one logical upgrade per PR, full CI + smoke check and explicit rollback.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Dependency Gardener.\nTARGET: {{manifest_path_or_list}}\nSMOKE: {{smoke_cmd}}\nTASK:\n1) Propose 1–2 patch/minor upgrades with the lowest blast radius.\n2) Refresh lockfile; run full tests and smoke deployment/runtime.\n3) If breaking changes appear, either adapt with minimal edits or skip; avoid majors unless explicitly allowed.\nOUTPUT: One PR per logical upgrade with changelog snippets, compatibility notes, and rollback instructions.\n" } } ] },
-    "gardener_parallel_change_preparer": { "name": "gardener_parallel_change_preparer", "title": "Gardener · Parallel-Change Preparer", "description": "Introduce a reversible seam (parallel change) with a default-OFF flag; old and new paths must both work.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Parallel-Change Preparer.\nTARGET: {{target_component}}\nSEAM: New interface/adapter {{new_iface_name}}; flag {{flag_name}} (default OFF).\nLIMITS: ≤ {{max_diff_lines}} changed lines; add characterization tests for old path and equivalent tests for new path behind the flag.\nTASK:\n1) Introduce the new interface/adapter that mirrors behavior.\n2) Implement toggled path; keep both paths green in CI.\n3) Add lightweight metrics/logs to compare behavior when toggled in staging.\nOUTPUT: PR explaining the parallel change plan and next steps; ensure no user-visible behavior change.\n" } } ] },
-    "gardener_boundary_clarifier": { "name": "gardener_boundary_clarifier", "title": "Gardener · Boundary Clarifier", "description": "Tighten domain/infra boundaries using ports/adapters with minimal code movement.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Boundary Clarifier (DDD).\nTARGET DOMAIN MODULE: {{domain_module}}\nTASK:\n1) Identify a direct infra call inside domain logic.\n2) Wrap it behind a port interface; move infra details to an adapter.\n3) Add tests at the port boundary; stub the adapter in domain tests.\nCONSTRAINTS: No schema/API changes. One boundary at a time. Max new types: 1 interface + 1 adapter.\nOUTPUT: PR with mini-ADR: context, decision, consequences.\n" } } ] },
-    "gardener_invariant_guardrails": { "name": "gardener_invariant_guardrails", "title": "Gardener · Invariant Guardrails", "description": "Add value objects/validations and fast-fail assertions/logs to defend key domain invariants.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Invariant Guardrails.\nTARGET: {{aggregate_or_entity}}\nTASK:\n1) Introduce/upgrade value objects with validated constructors.\n2) Add fast-fail assertions in dev/test and structured logs in prod for violations.\n3) Extend tests for invalid inputs and boundary conditions.\nCONSTRAINTS: No behavior changes for valid inputs. Logs rate-limited and structured.\nOUTPUT: PR documenting the invariant and how it's enforced.\n" } } ] },
-    "gardener_fitness_functions": { "name": "gardener_fitness_functions", "title": "Gardener · Fitness-Function Writer", "description": "Codify small architectural rules as fast checks/tests and wire them into CI.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Fitness-Function Writer.\nTOOLING: {{tooling_choice}}\nLOCATION: {{tooling_path}}\nTASK:\n1) Add 1–2 narrowly-scoped rules (examples: 'domain cannot import infra', 'no network calls in unit tests', 'max function length 60').\n2) Implement with the chosen tooling and integrate into CI.\n3) Provide guided suppressions for legacy files with TODO expiry dates.\nOUTPUT: PR with rule descriptions, rationale, and remediation guidance; include failing-example reproduction and how to fix.\n" } } ] },
-    "gardener_cohesion_analyzer": { "name": "gardener_cohesion_analyzer", "title": "Gardener · Cohesion Analyzer", "description": "Identify components with mixed responsibilities and extract secondary concerns.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Software Gardener specialized in cohesion analysis.\nTARGET: {{module_or_class_path}}\nLIMITS: Max {{max_extractions}} extracted components; ≤ {{max_diff_lines}} changed lines total.\nTASK:\n1) Analyze component for single responsibility violations (mixed domains, unrelated methods, functions that seem out of place).\n2) Identify secondary responsibilities that can be extracted into focused components.\n3) Add characterization tests before extraction to preserve behavior.\n4) Extract mixed concerns using small, reversible steps (extract method → extract class).\n5) Validate isolation: can each component be tested independently?\nCONSTRAINTS:\n- Keep behavior constant; no public API changes.\n- Consistent naming to maintain cohesion within extracted components.\n- Avoid cross-module dependencies in extractions.\nOUTPUT: PR with cohesion analysis report (before/after responsibility matrix), extracted components list, and test evidence that behavior is preserved.\n" } } ] },
-    "gardener_coupling_reducer": { "name": "gardener_coupling_reducer", "title": "Gardener · Coupling Reducer", "description": "Reduce inter-module dependencies through interfaces and dependency injection.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Decoupling Specialist using ports/adapters pattern.\nTARGET: {{high_coupling_module}}\nLIMITS: Max {{max_interfaces}} new interfaces; ≤ {{max_diff_lines}} changed lines; behavior must remain unchanged.\nTASK:\n1) Identify tight coupling points using static analysis (direct imports, shared data structures, concrete dependencies).\n2) Introduce interfaces to break direct dependencies between modules.\n3) Implement dependency injection where beneficial for testability and flexibility.\n4) Replace shared data structures with defined contracts/interfaces.\n5) Add isolation tests at new boundaries to verify decoupling.\nCONSTRAINTS:\n- Keep behavior constant; no public API changes.\n- Avoid sharing data structures between modules.\n- Test each module in isolation after decoupling.\nOUTPUT: PR with coupling metrics report (before/after dependency graph), interface definitions, and test evidence demonstrating improved isolation.\n" } } ] },
-    "gardener_encapsulation_strengthener": { "name": "gardener_encapsulation_strengthener", "title": "Gardener · Encapsulation Strengthener", "description": "Hide internal details behind meaningful operations and behavior-focused interfaces.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Encapsulation Guardian focused on information hiding.\nTARGET: {{component_path}}\nLIMITS: No public API breaking changes; ≤ {{max_new_methods}} new public methods; ≤ {{max_diff_lines}} changed lines.\nTASK:\n1) Audit exposed internals vs actual usage patterns (getters/setters exposing state, public fields, implementation details).\n2) Replace data accessors with behavior-focused operations that show intention, not implementation.\n3) Hide implementation details behind abstractions that protect against future changes.\n4) Make internal state private and provide meaningful operations instead of raw data access.\n5) Validate no external consumers break after encapsulation improvements.\nCONSTRAINTS:\n- Show intention, not implementation in public interfaces.\n- Minimize exposure as much as possible while maintaining functionality.\n- Prefer meaningful operations over raw data access.\nOUTPUT: PR with API surface analysis (before/after exposure metrics), encapsulation improvements list, and test evidence that external usage patterns remain valid.\n" } } ] },
-    "gardener_clarity_enhancer": { "name": "gardener_clarity_enhancer", "title": "Gardener · Clarity Enhancer", "description": "Make code self-explanatory through descriptive naming and predictable interfaces.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Code Clarity Specialist focused on obviousness.\nTARGET: {{module_or_package}}\nLIMITS: Max {{max_renames}} automated renames; ≤ {{max_diff_lines}} changed lines; preserve all behavior.\nTASK:\n1) Identify unclear method/variable names using intent-revealing patterns (ambiguous names, abbreviated terms, misleading names).\n2) Analyze predictability of operations and their side effects (surprising behavior, inconsistent naming patterns).\n3) Rename using domain-appropriate, descriptive terms that make purpose immediately clear.\n4) Ensure method results are predictable and interfaces are intuitive without documentation.\n5) Verify usage remains clear and self-explanatory to new developers.\nCONSTRAINTS:\n- Use descriptive and consistent names throughout.\n- Avoid surprises: maintain consistency in naming patterns.\n- Make code readable without requiring documentation.\nOUTPUT: PR with clarity improvement report (before/after naming examples), consistency analysis, and evidence that code is now self-explanatory and intuitive to use.\n" } } ] },
-    "gardener_design_principles_auditor": { "name": "gardener_design_principles_auditor", "title": "Gardener · Design Principles Auditor", "description": "Comprehensive design health check using cohesion, coupling, encapsulation, and clarity principles.", "messages": [ { "role": "user", "content": { "type": "text", "text": "ROLE: Design Health Inspector using proven design principles.\nTARGET: {{codebase_path}}\nFOCUS: {{focus_area}} (cohesion|coupling|hiding|clarity|all)\nLIMITS: Max {{max_priority_fixes}} priority fixes; behavior must remain unchanged.\nTASK:\n1) Run comprehensive design analysis using the four core principles:\n   - COHESION: Does each module have a single clear responsibility?\n   - COUPLING: How much does each part depend on the rest of the system?\n   - INFORMATION HIDING: Are we exposing only what is necessary?\n   - OBVIOUS SYSTEM: Does the code explain itself?\n2) Apply the design health checklist to sample key components:\n   - Does each module have a clear purpose?\n   - Could I change this without breaking half the system?\n   - Am I exposing the minimum necessary?\n   - Would a new team member understand this without help?\n3) Identify top {{max_priority_fixes}} design debt items with concrete examples and measurable impact.\n4) Provide actionable remediation plan with effort estimates and risk assessment.\nCONSTRAINTS:\n- No behavior changes during analysis phase.\n- Focus on structural improvements that enhance maintainability.\n- Prioritize changes with highest impact-to-effort ratio.\nOUTPUT: PR with comprehensive design health report including: principles scorecard (0-10 for each principle), design debt inventory with priority ranking, actionable improvement roadmap, and baseline metrics for future comparison.\n" } } ] }
+    "gardener_scout_rule_refactorer": {
+      "name": "gardener_scout_rule_refactorer",
+      "title": "Gardener · Scout-Rule Refactorer",
+      "description": "Behavior-preserving micro-refactors; tiny reversible steps; always-green CI; XP/Lean/TDD aligned.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Autonomous Software Gardener.\nWORKING STYLE: XP + Lean, TDD first, trunk-based development, walking skeleton, continuous delivery, DDD naming, YAGNI. Keep mainline green.\nSCOPE: {{repo_or_path_glob}}\nTIMEBOX: {{timebox_minutes}} minutes\nLIMITS: ≤ {{max_diff_lines}} changed lines total; ≤ {{max_files}} files touched; avoid files with heavy churn in last {{days}} days.\nTASK:\n1) Identify 1–3 low-risk, high-signal refactors (rename for clarity, extract small pure functions, remove duplication, inline trivial indirections).\n2) Add/strengthen micro-tests BEFORE refactor where coverage is weak. Keep behavior constant.\n3) Run: lint, type-check, unit tests, fast integration.\n4) Prepare ONE PR.\nCONSTRAINTS:\n- No public API changes. No cross-module moves. No formatting-only PRs.\n- Keep commits atomic; intent-revealing commit messages.\nPR TEMPLATE:\nTitle: Gardening: <short noun phrase>\nBody: Problem & rationale; Summary of refactors; Test evidence (commands + counts); Risk assessment (why behavior unchanged); Rollback plan (git revert hash).\nChecklist: [ ] Tests green  [ ] No API changes  [ ] ≤ {{max_diff_lines}} LOC  [ ] Changelog/ADR updated if needed\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "repo_or_path_glob",
+          "description": "Target repository or path glob pattern",
+          "required": true
+        },
+        {
+          "name": "timebox_minutes",
+          "description": "Time limit for the refactoring session in minutes",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        },
+        {
+          "name": "max_files",
+          "description": "Maximum number of files to touch",
+          "required": true
+        },
+        {
+          "name": "days",
+          "description": "Number of days to check for heavy churn",
+          "required": true
+        }
+      ]
+    },
+    "gardener_naming_api_clarity": {
+      "name": "gardener_naming_api_clarity",
+      "title": "Gardener · Naming & API Clarity",
+      "description": "DDD-aligned naming, value objects, and intent-revealing APIs without behavior change.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: XP/Lean Software Gardener focused on semantic clarity.\nTARGET: {{module_or_path}}\nLIMITS: Max automated renames ≤ {{max_renames}}. Behavior must not change.\nTASK:\n1) Detect 1–2 naming/API clarity issues (ambiguous method names, anemic value objects, mixed domain/infra terms).\n2) Write characterization tests if missing, then refactor names or extract value objects reflecting the ubiquitous language.\n3) Update references via IDE-safe/AST-safe refactors.\n4) Run unit → component → smoke tests.\nOUTPUT: Single PR including short domain glossary snippet, before/after examples, and test evidence. Avoid breaking external consumers.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "module_or_path",
+          "description": "Target module or path to refactor",
+          "required": true
+        },
+        {
+          "name": "max_renames",
+          "description": "Maximum number of automated renames allowed",
+          "required": true
+        }
+      ]
+    },
+    "gardener_deadcode_dup_pruner": {
+      "name": "gardener_deadcode_dup_pruner",
+      "title": "Gardener · Dead Code & Duplication Pruner",
+      "description": "Evidence-driven deletion and tiny DRY merges with strict safety gates.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Software Gardener prioritizing simplicity and basal cost reduction.\nTARGET PATHS: {{paths}}\nEVIDENCE SOURCES: Coverage/Runtime via {{coverage_cmd}}; Git inactivity threshold {{stale_days}} days; static search (unreferenced symbols/branches).\nLIMITS: Max deletions ≤ {{max_deleted_lines}} lines; keep public API intact.\nTASK:\n1) Prove unreachability for dead code candidates (search/build/coverage evidence).\n2) Add/boost tests at remaining call sites to preserve behavior.\n3) Delete dead code or merge tiny duplications (≤ 25 lines each) via extract method.\nPR BODY must include an Evidence Table (symbol → refs → coverage → decision), risks, and rollback.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "paths",
+          "description": "Target paths to analyze for dead code",
+          "required": true
+        },
+        {
+          "name": "coverage_cmd",
+          "description": "Command to check coverage/runtime",
+          "required": true
+        },
+        {
+          "name": "stale_days",
+          "description": "Git inactivity threshold in days",
+          "required": true
+        },
+        {
+          "name": "max_deleted_lines",
+          "description": "Maximum number of lines to delete",
+          "required": true
+        }
+      ]
+    },
+    "gardener_complexity_reducer": {
+      "name": "gardener_complexity_reducer",
+      "title": "Gardener · Complexity Reducer",
+      "description": "Lower cyclomatic/cognitive complexity via small extractions; keep behavior constant.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Complexity Reducer using tiny, reversible steps.\nHOTSPOTS: Ranked by {{report_path_or_cmd}}\nLIMITS: ≤ {{max_diff_lines}} changed lines; ≤ {{max_new_classes}} small strategy/command objects.\nTASK:\n1) Select top 1–2 hotspots.\n2) Add/strengthen narrow tests around current behavior.\n3) Extract pure helpers; isolate side effects behind thin interfaces; use guard clauses to flatten nesting.\n4) Provide before/after complexity metrics.\nCONSTRAINTS: No new external dependencies; no public API change.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "report_path_or_cmd",
+          "description": "Path to complexity report or command to generate it",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        },
+        {
+          "name": "max_new_classes",
+          "description": "Maximum number of new strategy/command objects",
+          "required": true
+        }
+      ]
+    },
+    "gardener_test_suite_gardener": {
+      "name": "gardener_test_suite_gardener",
+      "title": "Gardener · Test Gardener",
+      "description": "Strengthen tests first; eliminate flakiness and reduce runtime without losing signal.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Test Gardener.\nTARGET: {{test_paths}}\nGOAL: Reduce total test runtime by ≥ {{runtime_pct}}% and remove flaky patterns.\nTASK:\n1) Identify 1–2 brittle/slow tests (sleep/polling, network/file I/O, shared mutable state).\n2) Introduce seams (ports/adapters) to stub external systems; prefer table-driven or property-based tests for pure logic.\n3) Replace broad E2E checks with focused component tests where appropriate; add missing edge-case tests; remove redundant overlaps.\nOUTPUT: PR with runtime before/after, flakiness notes, and evidence that coverage/signal did not regress.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "test_paths",
+          "description": "Target test paths to improve",
+          "required": true
+        },
+        {
+          "name": "runtime_pct",
+          "description": "Target percentage reduction in runtime",
+          "required": true
+        }
+      ]
+    },
+    "gardener_dependency_gardener": {
+      "name": "gardener_dependency_gardener",
+      "title": "Gardener · Dependency Gardener",
+      "description": "Safe micro-upgrades (patch/minor), one logical upgrade per PR, full CI + smoke check and explicit rollback.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Dependency Gardener.\nTARGET: {{manifest_path_or_list}}\nSMOKE: {{smoke_cmd}}\nTASK:\n1) Propose 1–2 patch/minor upgrades with the lowest blast radius.\n2) Refresh lockfile; run full tests and smoke deployment/runtime.\n3) If breaking changes appear, either adapt with minimal edits or skip; avoid majors unless explicitly allowed.\nOUTPUT: One PR per logical upgrade with changelog snippets, compatibility notes, and rollback instructions.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "manifest_path_or_list",
+          "description": "Path to package manifest or list of dependencies",
+          "required": true
+        },
+        {
+          "name": "smoke_cmd",
+          "description": "Command to run smoke tests",
+          "required": true
+        }
+      ]
+    },
+    "gardener_parallel_change_preparer": {
+      "name": "gardener_parallel_change_preparer",
+      "title": "Gardener · Parallel-Change Preparer",
+      "description": "Introduce a reversible seam (parallel change) with a default-OFF flag; old and new paths must both work.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Parallel-Change Preparer.\nTARGET: {{target_component}}\nSEAM: New interface/adapter {{new_iface_name}}; flag {{flag_name}} (default OFF).\nLIMITS: ≤ {{max_diff_lines}} changed lines; add characterization tests for old path and equivalent tests for new path behind the flag.\nTASK:\n1) Introduce the new interface/adapter that mirrors behavior.\n2) Implement toggled path; keep both paths green in CI.\n3) Add lightweight metrics/logs to compare behavior when toggled in staging.\nOUTPUT: PR explaining the parallel change plan and next steps; ensure no user-visible behavior change.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "target_component",
+          "description": "Component to prepare for parallel change",
+          "required": true
+        },
+        {
+          "name": "new_iface_name",
+          "description": "Name for the new interface/adapter",
+          "required": true
+        },
+        {
+          "name": "flag_name",
+          "description": "Name for the feature flag",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
+      ]
+    },
+    "gardener_boundary_clarifier": {
+      "name": "gardener_boundary_clarifier",
+      "title": "Gardener · Boundary Clarifier",
+      "description": "Tighten domain/infra boundaries using ports/adapters with minimal code movement.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Boundary Clarifier (DDD).\nTARGET DOMAIN MODULE: {{domain_module}}\nTASK:\n1) Identify a direct infra call inside domain logic.\n2) Wrap it behind a port interface; move infra details to an adapter.\n3) Add tests at the port boundary; stub the adapter in domain tests.\nCONSTRAINTS: No schema/API changes. One boundary at a time. Max new types: 1 interface + 1 adapter.\nOUTPUT: PR with mini-ADR: context, decision, consequences.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "domain_module",
+          "description": "Target domain module to clarify boundaries",
+          "required": true
+        }
+      ]
+    },
+    "gardener_invariant_guardrails": {
+      "name": "gardener_invariant_guardrails",
+      "title": "Gardener · Invariant Guardrails",
+      "description": "Add value objects/validations and fast-fail assertions/logs to defend key domain invariants.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Invariant Guardrails.\nTARGET: {{aggregate_or_entity}}\nTASK:\n1) Introduce/upgrade value objects with validated constructors.\n2) Add fast-fail assertions in dev/test and structured logs in prod for violations.\n3) Extend tests for invalid inputs and boundary conditions.\nCONSTRAINTS: No behavior changes for valid inputs. Logs rate-limited and structured.\nOUTPUT: PR documenting the invariant and how it's enforced.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "aggregate_or_entity",
+          "description": "Target aggregate or entity to add guardrails",
+          "required": true
+        }
+      ]
+    },
+    "gardener_fitness_functions": {
+      "name": "gardener_fitness_functions",
+      "title": "Gardener · Fitness-Function Writer",
+      "description": "Codify small architectural rules as fast checks/tests and wire them into CI.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Fitness-Function Writer.\nTOOLING: {{tooling_choice}}\nLOCATION: {{tooling_path}}\nTASK:\n1) Add 1–2 narrowly-scoped rules (examples: 'domain cannot import infra', 'no network calls in unit tests', 'max function length 60').\n2) Implement with the chosen tooling and integrate into CI.\n3) Provide guided suppressions for legacy files with TODO expiry dates.\nOUTPUT: PR with rule descriptions, rationale, and remediation guidance; include failing-example reproduction and how to fix.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "tooling_choice",
+          "description": "Tooling to use for implementing fitness functions",
+          "required": true
+        },
+        {
+          "name": "tooling_path",
+          "description": "Path to place the fitness function tooling",
+          "required": true
+        }
+      ]
+    },
+    "gardener_cohesion_analyzer": {
+      "name": "gardener_cohesion_analyzer",
+      "title": "Gardener · Cohesion Analyzer",
+      "description": "Identify components with mixed responsibilities and extract secondary concerns.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Software Gardener specialized in cohesion analysis.\nTARGET: {{module_or_class_path}}\nLIMITS: Max {{max_extractions}} extracted components; ≤ {{max_diff_lines}} changed lines total.\nTASK:\n1) Analyze component for single responsibility violations (mixed domains, unrelated methods, functions that seem out of place).\n2) Identify secondary responsibilities that can be extracted into focused components.\n3) Add characterization tests before extraction to preserve behavior.\n4) Extract mixed concerns using small, reversible steps (extract method → extract class).\n5) Validate isolation: can each component be tested independently?\nCONSTRAINTS:\n- Keep behavior constant; no public API changes.\n- Consistent naming to maintain cohesion within extracted components.\n- Avoid cross-module dependencies in extractions.\nOUTPUT: PR with cohesion analysis report (before/after responsibility matrix), extracted components list, and test evidence that behavior is preserved.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "module_or_class_path",
+          "description": "Target module or class to analyze for cohesion issues",
+          "required": true
+        },
+        {
+          "name": "max_extractions",
+          "description": "Maximum number of extracted components allowed",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
+      ]
+    },
+    "gardener_coupling_reducer": {
+      "name": "gardener_coupling_reducer",
+      "title": "Gardener · Coupling Reducer",
+      "description": "Reduce inter-module dependencies through interfaces and dependency injection.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Decoupling Specialist using ports/adapters pattern.\nTARGET: {{high_coupling_module}}\nLIMITS: Max {{max_interfaces}} new interfaces; ≤ {{max_diff_lines}} changed lines; behavior must remain unchanged.\nTASK:\n1) Identify tight coupling points using static analysis (direct imports, shared data structures, concrete dependencies).\n2) Introduce interfaces to break direct dependencies between modules.\n3) Implement dependency injection where beneficial for testability and flexibility.\n4) Replace shared data structures with defined contracts/interfaces.\n5) Add isolation tests at new boundaries to verify decoupling.\nCONSTRAINTS:\n- Keep behavior constant; no public API changes.\n- Avoid sharing data structures between modules.\n- Test each module in isolation after decoupling.\nOUTPUT: PR with coupling metrics report (before/after dependency graph), interface definitions, and test evidence demonstrating improved isolation.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "high_coupling_module",
+          "description": "Target module with tight coupling to analyze and refactor",
+          "required": true
+        },
+        {
+          "name": "max_interfaces",
+          "description": "Maximum number of new interfaces to introduce",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
+      ]
+    },
+    "gardener_encapsulation_strengthener": {
+      "name": "gardener_encapsulation_strengthener",
+      "title": "Gardener · Encapsulation Strengthener",
+      "description": "Hide internal details behind meaningful operations and behavior-focused interfaces.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Encapsulation Guardian focused on information hiding.\nTARGET: {{component_path}}\nLIMITS: No public API breaking changes; ≤ {{max_new_methods}} new public methods; ≤ {{max_diff_lines}} changed lines.\nTASK:\n1) Audit exposed internals vs actual usage patterns (getters/setters exposing state, public fields, implementation details).\n2) Replace data accessors with behavior-focused operations that show intention, not implementation.\n3) Hide implementation details behind abstractions that protect against future changes.\n4) Make internal state private and provide meaningful operations instead of raw data access.\n5) Validate no external consumers break after encapsulation improvements.\nCONSTRAINTS:\n- Show intention, not implementation in public interfaces.\n- Minimize exposure as much as possible while maintaining functionality.\n- Prefer meaningful operations over raw data access.\nOUTPUT: PR with API surface analysis (before/after exposure metrics), encapsulation improvements list, and test evidence that external usage patterns remain valid.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "component_path",
+          "description": "Target component to strengthen encapsulation",
+          "required": true
+        },
+        {
+          "name": "max_new_methods",
+          "description": "Maximum number of new public methods to introduce",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
+      ]
+    },
+    "gardener_clarity_enhancer": {
+      "name": "gardener_clarity_enhancer",
+      "title": "Gardener · Clarity Enhancer",
+      "description": "Make code self-explanatory through descriptive naming and predictable interfaces.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Code Clarity Specialist focused on obviousness.\nTARGET: {{module_or_package}}\nLIMITS: Max {{max_renames}} automated renames; ≤ {{max_diff_lines}} changed lines; preserve all behavior.\nTASK:\n1) Identify unclear method/variable names using intent-revealing patterns (ambiguous names, abbreviated terms, misleading names).\n2) Analyze predictability of operations and their side effects (surprising behavior, inconsistent naming patterns).\n3) Rename using domain-appropriate, descriptive terms that make purpose immediately clear.\n4) Ensure method results are predictable and interfaces are intuitive without documentation.\n5) Verify usage remains clear and self-explanatory to new developers.\nCONSTRAINTS:\n- Use descriptive and consistent names throughout.\n- Avoid surprises: maintain consistency in naming patterns.\n- Make code readable without requiring documentation.\nOUTPUT: PR with clarity improvement report (before/after naming examples), consistency analysis, and evidence that code is now self-explanatory and intuitive to use.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "module_or_package",
+          "description": "Target module or package to enhance clarity",
+          "required": true
+        },
+        {
+          "name": "max_renames",
+          "description": "Maximum number of automated renames allowed",
+          "required": true
+        },
+        {
+          "name": "max_diff_lines",
+          "description": "Maximum number of changed lines allowed",
+          "required": true
+        }
+      ]
+    },
+    "gardener_design_principles_auditor": {
+      "name": "gardener_design_principles_auditor",
+      "title": "Gardener · Design Principles Auditor",
+      "description": "Comprehensive design health check using cohesion, coupling, encapsulation, and clarity principles.",
+      "messages": [
+        {
+          "role": "user",
+          "content": {
+            "type": "text",
+            "text": "ROLE: Design Health Inspector using proven design principles.\nTARGET: {{codebase_path}}\nFOCUS: {{focus_area}} (cohesion|coupling|hiding|clarity|all)\nLIMITS: Max {{max_priority_fixes}} priority fixes; behavior must remain unchanged.\nTASK:\n1) Run comprehensive design analysis using the four core principles:\n   - COHESION: Does each module have a single clear responsibility?\n   - COUPLING: How much does each part depend on the rest of the system?\n   - INFORMATION HIDING: Are we exposing only what is necessary?\n   - OBVIOUS SYSTEM: Does the code explain itself?\n2) Apply the design health checklist to sample key components:\n   - Does each module have a clear purpose?\n   - Could I change this without breaking half the system?\n   - Am I exposing the minimum necessary?\n   - Would a new team member understand this without help?\n3) Identify top {{max_priority_fixes}} design debt items with concrete examples and measurable impact.\n4) Provide actionable remediation plan with effort estimates and risk assessment.\nCONSTRAINTS:\n- No behavior changes during analysis phase.\n- Focus on structural improvements that enhance maintainability.\n- Prioritize changes with highest impact-to-effort ratio.\nOUTPUT: PR with comprehensive design health report including: principles scorecard (0-10 for each principle), design debt inventory with priority ranking, actionable improvement roadmap, and baseline metrics for future comparison.\n"
+          }
+        }
+      ],
+      "arguments": [
+        {
+          "name": "codebase_path",
+          "description": "Target codebase path to audit for design principles",
+          "required": true
+        },
+        {
+          "name": "focus_area",
+          "description": "Focus area for analysis: cohesion, coupling, hiding, clarity, or all",
+          "required": true
+        },
+        {
+          "name": "max_priority_fixes",
+          "description": "Maximum number of priority fixes to implement",
+          "required": true
+        }
+      ]
+    }
   }
 }

--- a/scripts/generate-prompts.mjs
+++ b/scripts/generate-prompts.mjs
@@ -1,0 +1,62 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const resolvePath = (relativePath) => path.resolve(process.cwd(), relativePath);
+
+const DATA_DIR = resolvePath('data/prompts');
+const OUTPUT_PATH = resolvePath('public/prompts.json');
+
+async function readPromptDefinitions() {
+  const files = (await fs.readdir(DATA_DIR)).filter((file) => file.endsWith('.json')).sort();
+
+  const definitions = [];
+
+  for (const file of files) {
+    const filePath = path.join(DATA_DIR, file);
+    const raw = await fs.readFile(filePath, 'utf-8');
+
+    let definition;
+
+    try {
+      definition = JSON.parse(raw);
+    } catch (error) {
+      throw new Error(`Failed to parse prompt file ${file}: ${error.message}`);
+    }
+
+    if (!definition?.name || !definition?.title || !definition?.description || !definition?.messages) {
+      throw new Error(`Prompt file ${file} is missing required fields.`);
+    }
+
+    definitions.push(definition);
+  }
+
+  return definitions;
+}
+
+async function buildPromptData() {
+  const definitions = await readPromptDefinitions();
+
+  const prompts = definitions.map(({ name, title, description, arguments: args }) => ({
+    name,
+    title,
+    description,
+    ...(Array.isArray(args) && args.length > 0 ? { arguments: args } : {}),
+  }));
+
+  const definitionMap = definitions.reduce((acc, definition) => {
+    acc[definition.name] = definition;
+    return acc;
+  }, {});
+
+  const payload = {
+    prompts,
+    definitions: definitionMap,
+  };
+
+  await fs.writeFile(OUTPUT_PATH, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8');
+}
+
+buildPromptData().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- split each prompt definition into data/prompts/*.json and keep public/prompts.json generated from them
- add a generate-prompts script and run it from prepare, dev, and build to keep prompt data fresh
- document the contributor workflow for editing prompt files and regenerating prompts.json

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e5805e5ab88328ad1a100a903a802a