### PR TITLE
Fix API docs endpoint to reflect deployment base URL

### DIFF
--- a/src/pages/API/index.test.tsx
+++ b/src/pages/API/index.test.tsx
@@ -35,10 +35,18 @@ describe('API', () => {
     expect(screen.getByRole('heading', { name: /best practices/i })).toBeInTheDocument()
   })
 
+  const getExpectedEndpoint = () => {
+    const basePath = import.meta.env.BASE_URL.endsWith('/')
+      ? import.meta.env.BASE_URL
+      : `${import.meta.env.BASE_URL}/`
+
+    return `${window.location.origin}${basePath}prompts.json`
+  }
+
   it('should display the API endpoint', () => {
     render(<API />)
-    
-    expect(screen.getByText('http://localhost:5173/prompts.json')).toBeInTheDocument()
+
+    expect(screen.getByText(getExpectedEndpoint())).toBeInTheDocument()
   })
 
   it('should show API details', () => {
@@ -58,7 +66,7 @@ describe('API', () => {
     fireEvent.click(copyButton)
     
     await waitFor(() => {
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('http://localhost:5173/prompts.json')
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(getExpectedEndpoint())
     })
     
     expect(screen.getByText('Copied')).toBeInTheDocument()

--- a/src/pages/API/index.tsx
+++ b/src/pages/API/index.tsx
@@ -3,7 +3,13 @@ import { CodeBracketIcon, DocumentDuplicateIcon, CheckIcon } from '@heroicons/re
 
 export default function API() {
   const [copied, setCopied] = useState(false)
-  const apiEndpoint = 'http://localhost:5173/prompts.json'
+  const apiEndpoint = (() => {
+    const origin = typeof window !== 'undefined' ? window.location.origin : ''
+    const basePath = import.meta.env.BASE_URL?.length ? import.meta.env.BASE_URL : '/'
+    const normalizedBasePath = basePath.endsWith('/') ? basePath : `${basePath}/`
+
+    return `${origin}${normalizedBasePath}prompts.json`
+  })()
 
   const copyToClipboard = async () => {
     try {


### PR DESCRIPTION
## Summary
- compute the API documentation endpoint from the current origin and Vite base path
- update the API page tests to expect the dynamic endpoint for display and copy behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e58778280483289df26c93e2da26c0