### PR TITLE
Add prompt categories and category filters

### DIFF
--- a/data/prompts/analyst-debt.yaml
+++ b/data/prompts/analyst-debt.yaml
@@ -1,6 +1,8 @@
 name: analyst_debt
 title: Analyst · Technical Debt
 description: Identify and prioritize technical debt by ROI.
+categories:
+  - Analyst
 messages:
   - role: user
     content:

--- a/data/prompts/analyst-review.yaml
+++ b/data/prompts/analyst-review.yaml
@@ -1,6 +1,8 @@
 name: analyst_review
 title: Analyst · Code Review
 description: XP-style review of pending changes. Tests, maintainability, project rules.
+categories:
+  - Analyst
 messages:
   - role: user
     content:

--- a/data/prompts/analyst-risks.yaml
+++ b/data/prompts/analyst-risks.yaml
@@ -1,6 +1,8 @@
 name: analyst_risks
 title: Analyst · Predict Risks
 description: Predict where code is likely to fail in production.
+categories:
+  - Analyst
 messages:
   - role: user
     content:

--- a/data/prompts/analyst-security.yaml
+++ b/data/prompts/analyst-security.yaml
@@ -1,6 +1,8 @@
 name: analyst_security
 title: Analyst · Security
 description: Pragmatic security analysis. Real risks, simple mitigations.
+categories:
+  - Analyst
 messages:
   - role: user
     content:

--- a/data/prompts/clarity-naming.yaml
+++ b/data/prompts/clarity-naming.yaml
@@ -1,6 +1,8 @@
 name: clarity_naming
 title: Clarity · Naming
 description: Improve naming and API clarity. Make code self-explanatory.
+categories:
+  - Clarity
 messages:
   - role: user
     content:

--- a/data/prompts/gardener-prune.yaml
+++ b/data/prompts/gardener-prune.yaml
@@ -1,6 +1,8 @@
 name: gardener_prune
 title: Gardener · Prune
 description: Remove dead code and small duplications with evidence.
+categories:
+  - Gardener
 messages:
   - role: user
     content:

--- a/data/prompts/gardener-refactor.yaml
+++ b/data/prompts/gardener-refactor.yaml
@@ -1,6 +1,8 @@
 name: gardener_refactor
 title: Gardener · Refactor
 description: Small, safe, behavior-preserving micro-refactors. Scout rule.
+categories:
+  - Gardener
 messages:
   - role: user
     content:

--- a/data/prompts/gardener-simplify.yaml
+++ b/data/prompts/gardener-simplify.yaml
@@ -1,6 +1,8 @@
 name: gardener_simplify
 title: Gardener · Simplify
 description: Reduce complexity via small extractions. Keep behavior constant.
+categories:
+  - Gardener
 messages:
   - role: user
     content:

--- a/data/prompts/gardener-upgrade.yaml
+++ b/data/prompts/gardener-upgrade.yaml
@@ -1,6 +1,8 @@
 name: gardener_upgrade
 title: Gardener · Upgrade
 description: Safe dependency upgrades. One at a time. Full test cycle.
+categories:
+  - Gardener
 messages:
   - role: user
     content:

--- a/data/prompts/planner-coverage.yaml
+++ b/data/prompts/planner-coverage.yaml
@@ -1,6 +1,8 @@
 name: planner_coverage
 title: Planner · Test Coverage
 description: Plan and write tests for untested code. Behavior-focused.
+categories:
+  - Planner
 messages:
   - role: user
     content:

--- a/data/prompts/planner-mikado.yaml
+++ b/data/prompts/planner-mikado.yaml
@@ -1,6 +1,8 @@
 name: planner_mikado
 title: Planner · Mikado Method
 description: Break complex changes into safe, incremental steps.
+categories:
+  - Planner
 messages:
   - role: user
     content:

--- a/public/prompts.json
+++ b/public/prompts.json
@@ -3,57 +3,90 @@
     {
       "name": "analyst_debt",
       "title": "Analyst · Technical Debt",
-      "description": "Identify and prioritize technical debt by ROI."
+      "description": "Identify and prioritize technical debt by ROI.",
+      "categories": [
+        "Analyst"
+      ]
     },
     {
       "name": "analyst_review",
       "title": "Analyst · Code Review",
-      "description": "XP-style review of pending changes. Tests, maintainability, project rules."
+      "description": "XP-style review of pending changes. Tests, maintainability, project rules.",
+      "categories": [
+        "Analyst"
+      ]
     },
     {
       "name": "analyst_risks",
       "title": "Analyst · Predict Risks",
-      "description": "Predict where code is likely to fail in production."
+      "description": "Predict where code is likely to fail in production.",
+      "categories": [
+        "Analyst"
+      ]
     },
     {
       "name": "analyst_security",
       "title": "Analyst · Security",
-      "description": "Pragmatic security analysis. Real risks, simple mitigations."
+      "description": "Pragmatic security analysis. Real risks, simple mitigations.",
+      "categories": [
+        "Analyst"
+      ]
     },
     {
       "name": "clarity_naming",
       "title": "Clarity · Naming",
-      "description": "Improve naming and API clarity. Make code self-explanatory."
+      "description": "Improve naming and API clarity. Make code self-explanatory.",
+      "categories": [
+        "Clarity"
+      ]
     },
     {
       "name": "gardener_prune",
       "title": "Gardener · Prune",
-      "description": "Remove dead code and small duplications with evidence."
+      "description": "Remove dead code and small duplications with evidence.",
+      "categories": [
+        "Gardener"
+      ]
     },
     {
       "name": "gardener_refactor",
       "title": "Gardener · Refactor",
-      "description": "Small, safe, behavior-preserving micro-refactors. Scout rule."
+      "description": "Small, safe, behavior-preserving micro-refactors. Scout rule.",
+      "categories": [
+        "Gardener"
+      ]
     },
     {
       "name": "gardener_simplify",
       "title": "Gardener · Simplify",
-      "description": "Reduce complexity via small extractions. Keep behavior constant."
+      "description": "Reduce complexity via small extractions. Keep behavior constant.",
+      "categories": [
+        "Gardener"
+      ]
     },
     {
       "name": "gardener_upgrade",
       "title": "Gardener · Upgrade",
-      "description": "Safe dependency upgrades. One at a time. Full test cycle."
+      "description": "Safe dependency upgrades. One at a time. Full test cycle.",
+      "categories": [
+        "Gardener"
+      ]
     },
     {
       "name": "planner_coverage",
       "title": "Planner · Test Coverage",
-      "description": "Plan and write tests for untested code. Behavior-focused."
+      "description": "Plan and write tests for untested code. Behavior-focused.",
+      "categories": [
+        "Planner"
+      ]
     },
     {
       "name": "planner_mikado",
       "title": "Planner · Mikado Method",
-      "description": "Break complex changes into safe, incremental steps."
+      "description": "Break complex changes into safe, incremental steps.",
+      "categories": [
+        "Planner"
+      ]
     }
   ],
   "definitions": {
@@ -61,6 +94,9 @@
       "name": "analyst_debt",
       "title": "Analyst · Technical Debt",
       "description": "Identify and prioritize technical debt by ROI.",
+      "categories": [
+        "Analyst"
+      ],
       "messages": [
         {
           "role": "user",
@@ -75,6 +111,9 @@
       "name": "analyst_review",
       "title": "Analyst · Code Review",
       "description": "XP-style review of pending changes. Tests, maintainability, project rules.",
+      "categories": [
+        "Analyst"
+      ],
       "messages": [
         {
           "role": "user",
@@ -89,6 +128,9 @@
       "name": "analyst_risks",
       "title": "Analyst · Predict Risks",
       "description": "Predict where code is likely to fail in production.",
+      "categories": [
+        "Analyst"
+      ],
       "messages": [
         {
           "role": "user",
@@ -103,6 +145,9 @@
       "name": "analyst_security",
       "title": "Analyst · Security",
       "description": "Pragmatic security analysis. Real risks, simple mitigations.",
+      "categories": [
+        "Analyst"
+      ],
       "messages": [
         {
           "role": "user",
@@ -117,6 +162,9 @@
       "name": "clarity_naming",
       "title": "Clarity · Naming",
       "description": "Improve naming and API clarity. Make code self-explanatory.",
+      "categories": [
+        "Clarity"
+      ],
       "messages": [
         {
           "role": "user",
@@ -131,6 +179,9 @@
       "name": "gardener_prune",
       "title": "Gardener · Prune",
       "description": "Remove dead code and small duplications with evidence.",
+      "categories": [
+        "Gardener"
+      ],
       "messages": [
         {
           "role": "user",
@@ -145,6 +196,9 @@
       "name": "gardener_refactor",
       "title": "Gardener · Refactor",
       "description": "Small, safe, behavior-preserving micro-refactors. Scout rule.",
+      "categories": [
+        "Gardener"
+      ],
       "messages": [
         {
           "role": "user",
@@ -159,6 +213,9 @@
       "name": "gardener_simplify",
       "title": "Gardener · Simplify",
       "description": "Reduce complexity via small extractions. Keep behavior constant.",
+      "categories": [
+        "Gardener"
+      ],
       "messages": [
         {
           "role": "user",
@@ -173,6 +230,9 @@
       "name": "gardener_upgrade",
       "title": "Gardener · Upgrade",
       "description": "Safe dependency upgrades. One at a time. Full test cycle.",
+      "categories": [
+        "Gardener"
+      ],
       "messages": [
         {
           "role": "user",
@@ -187,6 +247,9 @@
       "name": "planner_coverage",
       "title": "Planner · Test Coverage",
       "description": "Plan and write tests for untested code. Behavior-focused.",
+      "categories": [
+        "Planner"
+      ],
       "messages": [
         {
           "role": "user",
@@ -201,6 +264,9 @@
       "name": "planner_mikado",
       "title": "Planner · Mikado Method",
       "description": "Break complex changes into safe, incremental steps.",
+      "categories": [
+        "Planner"
+      ],
       "messages": [
         {
           "role": "user",

--- a/scripts/generate-prompts.mjs
+++ b/scripts/generate-prompts.mjs
@@ -52,15 +52,16 @@ async function readPromptDefinitions() {
 async function buildPromptData() {
   const definitions = await readPromptDefinitions();
 
-  const prompts = definitions.map(({ name, title, description }) => ({
+  const prompts = definitions.map(({ name, title, description, categories = [] }) => ({
     name,
     title,
     description,
+    categories,
   }));
 
   const definitionMap = definitions.reduce((acc, definition) => {
-    const { name, title, description, messages } = definition;
-    acc[name] = { name, title, description, messages };
+    const { name, title, description, categories = [], messages } = definition;
+    acc[name] = { name, title, description, categories, messages };
     return acc;
   }, {});
 

--- a/src/components/PromptCard/index.tsx
+++ b/src/components/PromptCard/index.tsx
@@ -22,6 +22,18 @@ export default function PromptCard({ prompt }: PromptCardProps) {
         </div>
 
         <div className="flex items-center justify-end mt-4 pt-4 border-t border-gray-100">
+          {prompt.categories && prompt.categories.length > 0 && (
+            <div className="flex-1 flex flex-wrap gap-2">
+              {prompt.categories.map((category) => (
+                <span
+                  key={category}
+                  className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-1 text-xs font-medium text-indigo-700"
+                >
+                  {category}
+                </span>
+              ))}
+            </div>
+          )}
           <Link
             to={`/prompt/${prompt.name}`}
             className="inline-flex items-center px-3 py-2 text-sm font-medium text-indigo-600 bg-indigo-50 border border-transparent rounded-md hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors duration-200"

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -3,22 +3,24 @@ import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import PromptCard from '../../components/PromptCard'
 import SearchBox from '../../components/SearchBox'
 import { usePrompts } from '../../hooks/usePrompts'
+import { filterPrompts } from '../../utils/filterPrompts'
 
 export default function Home() {
   const { prompts, loading, error } = usePrompts()
   const [searchQuery, setSearchQuery] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+
+  const categories = useMemo(() => {
+    const categorySet = new Set<string>()
+    prompts.forEach((prompt) => {
+      prompt.categories?.forEach((category) => categorySet.add(category))
+    })
+    return Array.from(categorySet).sort()
+  }, [prompts])
 
   const filteredPrompts = useMemo(() => {
-    if (!searchQuery) return prompts
-
-    const query = searchQuery.toLowerCase()
-    return prompts.filter(
-      (prompt) =>
-        prompt.title.toLowerCase().includes(query) ||
-        prompt.description.toLowerCase().includes(query) ||
-        prompt.name.toLowerCase().includes(query)
-    )
-  }, [prompts, searchQuery])
+    return filterPrompts(prompts, searchQuery, selectedCategory)
+  }, [prompts, searchQuery, selectedCategory])
 
   if (loading) {
     return (
@@ -46,6 +48,38 @@ export default function Home() {
           placeholder="Search prompts by name, title, or description..."
         />
       </div>
+
+      {/* Category filters */}
+      {categories.length > 0 && (
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-sm text-gray-600">Quick filter:</span>
+          <button
+            type="button"
+            onClick={() => setSelectedCategory(null)}
+            className={`rounded-full px-4 py-1 text-sm font-medium transition-colors border ${
+              selectedCategory === null
+                ? 'bg-indigo-50 text-indigo-700 border-indigo-200'
+                : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'
+            }`}
+          >
+            All categories
+          </button>
+          {categories.map((category) => (
+            <button
+              type="button"
+              key={category}
+              onClick={() => setSelectedCategory(category)}
+              className={`rounded-full px-4 py-1 text-sm font-medium transition-colors border ${
+                selectedCategory === category
+                  ? 'bg-indigo-600 text-white border-indigo-600'
+                  : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'
+              }`}
+            >
+              {category}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* Stats */}
       <div className="text-center">

--- a/src/pages/PromptDetail/index.tsx
+++ b/src/pages/PromptDetail/index.tsx
@@ -130,10 +130,18 @@ export default function PromptDetail() {
           </p>
         </div>
 
-        <div className="flex items-center text-sm text-gray-500">
+        <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500">
           <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded-md text-xs font-medium">
             {prompt.name}
           </span>
+          {prompt.categories?.map((category) => (
+            <span
+              key={category}
+              className="px-2 py-1 bg-indigo-50 text-indigo-700 rounded-full text-xs font-medium"
+            >
+              {category}
+            </span>
+          ))}
         </div>
       </div>
 

--- a/src/types/prompt.ts
+++ b/src/types/prompt.ts
@@ -18,17 +18,15 @@ export interface PromptMessage {
   content: PromptContent
 }
 
-export interface PromptDefinition {
-  name: string
-  title: string
-  description: string
-  messages: PromptMessage[]
-}
-
 export interface Prompt {
   name: string
   title: string
   description: string
+  categories?: string[]
+}
+
+export interface PromptDefinition extends Prompt {
+  messages: PromptMessage[]
 }
 
 export interface PromptData {

--- a/src/utils/filterPrompts.test.ts
+++ b/src/utils/filterPrompts.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { filterPrompts } from './filterPrompts'
+import type { Prompt } from '../types/prompt'
+
+describe('filterPrompts', () => {
+  const prompts: Prompt[] = [
+    { name: 'analyst_review', title: 'Analyst Review', description: 'Code review prompt', categories: ['Analyst'] },
+    { name: 'gardener_prune', title: 'Gardener Prune', description: 'Cleanup prompt', categories: ['Gardener'] },
+    { name: 'planner_mikado', title: 'Planner Mikado Method', description: 'Planning prompt', categories: ['Planner'] },
+    { name: 'clarity_naming', title: 'Clarity Naming', description: 'Improve naming' }
+  ]
+
+  it('returns all prompts when no search query or category is applied', () => {
+    const result = filterPrompts(prompts, '', null)
+    expect(result).toHaveLength(prompts.length)
+  })
+
+  it('filters prompts by search query across name, title, and description', () => {
+    const result = filterPrompts(prompts, 'prune', null)
+    expect(result).toEqual([
+      { name: 'gardener_prune', title: 'Gardener Prune', description: 'Cleanup prompt', categories: ['Gardener'] }
+    ])
+  })
+
+  it('filters prompts by selected category', () => {
+    const result = filterPrompts(prompts, '', 'Analyst')
+    expect(result).toEqual([
+      { name: 'analyst_review', title: 'Analyst Review', description: 'Code review prompt', categories: ['Analyst'] }
+    ])
+  })
+
+  it('applies both search and category filters together', () => {
+    const result = filterPrompts(prompts, 'prompt', 'Gardener')
+    expect(result).toEqual([
+      { name: 'gardener_prune', title: 'Gardener Prune', description: 'Cleanup prompt', categories: ['Gardener'] }
+    ])
+  })
+
+  it('treats missing categories as empty arrays when filtering', () => {
+    const result = filterPrompts(prompts, '', 'Clarity')
+    expect(result).toEqual([])
+  })
+})

--- a/src/utils/filterPrompts.ts
+++ b/src/utils/filterPrompts.ts
@@ -1,0 +1,20 @@
+import type { Prompt } from '../types/prompt'
+
+export function filterPrompts(prompts: Prompt[], searchQuery: string, selectedCategory: string | null): Prompt[] {
+  const query = searchQuery.trim().toLowerCase()
+
+  return prompts.filter((prompt) => {
+    const matchesQuery =
+      query.length === 0 ||
+      prompt.name.toLowerCase().includes(query) ||
+      prompt.title.toLowerCase().includes(query) ||
+      prompt.description.toLowerCase().includes(query)
+
+    const categories = prompt.categories ?? []
+    const matchesCategory =
+      selectedCategory === null ||
+      categories.some((category) => category === selectedCategory)
+
+    return matchesQuery && matchesCategory
+  })
+}

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -6,13 +6,19 @@ describe('validatePromptData', () => {
   it('should return valid data when structure is correct', () => {
     const validData: PromptData = {
       prompts: [
-        { name: 'test', title: 'Test', description: 'A test prompt' }
+        {
+          name: 'test',
+          title: 'Test',
+          description: 'A test prompt',
+          categories: ['Example']
+        }
       ],
       definitions: {
         test: {
           name: 'test',
           title: 'Test',
           description: 'A test prompt',
+          categories: ['Example'],
           messages: []
         }
       }
@@ -68,6 +74,25 @@ describe('validatePromptData', () => {
       .toThrow(ValidationError)
     expect(() => validatePromptData(invalidData as unknown as PromptData))
       .toThrow('Invalid prompt at index 0: missing required field')
+  })
+
+  it('should throw ValidationError when categories is not an array of strings', () => {
+    const invalidData = {
+      prompts: [
+        {
+          name: 'test',
+          title: 'Test',
+          description: 'A test prompt',
+          categories: ['Valid', 123]
+        }
+      ],
+      definitions: {}
+    }
+
+    expect(() => validatePromptData(invalidData as unknown as PromptData))
+      .toThrow(ValidationError)
+    expect(() => validatePromptData(invalidData as unknown as PromptData))
+      .toThrow('Invalid prompt at index 0: categories must be an array of strings')
   })
 
   it('should return empty prompts array when valid but empty', () => {


### PR DESCRIPTION
## Summary
- add prompt categories across the data pipeline and generated prompt payloads
- add filtering utility plus Home page chips for quick category-based browsing
- surface category badges on prompt cards and the prompt detail view

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b4b2aeb2883289019b0b8592f000d)